### PR TITLE
Add uvx one-liner to uv install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,12 @@ print(output["choices"][0]["message"]["content"])
 ### uv (recommended)
 
 ```bash
+uvx whichllm
+```
+
+To install permanently:
+
+```bash
 uv tool install whichllm
 ```
 


### PR DESCRIPTION
Add `uvx whichllm` as the fastest way to try whichllm without permanently installing anything. This runs in a temporary environment — zero commitment, zero cleanup.

## What

Add `uvx whichllm` one-liner to the uv install section in README, above the existing `uv tool install` command.

## Why

`uvx` is the lowest-friction way to try whichllm — no permanent install, no cleanup. It deserves to be front and center in the uv section since most people just want to try it first.

## Testing

- [x] Tests pass (`pytest`) — docs-only change, no code modified
- [ ] ~~New tests added (if applicable)~~ — N/A
- [ ] ~~Tested on real hardware (if hardware-related)~~ — N/A

## Notes

Verified `uvx whichllm` works as expected — uv creates a temporary environment, runs the CLI, and cleans up.
