### PR TITLE
Add Linux Intel iGPU detection

### DIFF
--- a/src/whichllm/hardware/detector.py
+++ b/src/whichllm/hardware/detector.py
@@ -8,6 +8,7 @@ import platform
 from whichllm.hardware.amd import detect_amd_gpus
 from whichllm.hardware.apple import detect_apple_gpu
 from whichllm.hardware.cpu import detect_avx_support, detect_cpu_cores, detect_cpu_name
+from whichllm.hardware.intel import detect_intel_gpus
 from whichllm.hardware.memory import detect_disk_free_bytes, detect_ram_bytes
 from whichllm.hardware.nvidia import detect_nvidia_gpus
 from whichllm.hardware.types import HardwareInfo
@@ -26,6 +27,7 @@ def detect_hardware() -> HardwareInfo:
     gpus.extend(detect_nvidia_gpus())
     if os_name == "linux":
         gpus.extend(detect_amd_gpus())
+        gpus.extend(detect_intel_gpus())
     if os_name == "darwin":
         gpus.extend(detect_apple_gpu())
 

--- a/src/whichllm/hardware/intel.py
+++ b/src/whichllm/hardware/intel.py
@@ -1,0 +1,101 @@
+"""Intel integrated GPU detection on Linux."""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+
+from whichllm.hardware.types import GPUInfo
+
+logger = logging.getLogger(__name__)
+
+
+_DISPLAY_CLASSES = (
+    "vga compatible controller",
+    "3d controller",
+    "display controller",
+)
+
+
+def _normalize_lspci_name(line: str) -> str:
+    parts = [p.strip() for p in line.split('"') if p.strip() and p.strip() != "\t"]
+    for i, part in enumerate(parts):
+        if part.lower() == "intel corporation" and i + 1 < len(parts):
+            return parts[i + 1]
+    return "Intel Integrated Graphics"
+
+
+def _detect_from_lspci() -> list[str]:
+    try:
+        result = subprocess.run(
+            ["lspci", "-mm"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        logger.debug("lspci not available or timed out")
+        return []
+
+    if result.returncode != 0:
+        return []
+
+    names: list[str] = []
+    seen: set[str] = set()
+    for line in result.stdout.splitlines():
+        line_lower = line.lower()
+        if "intel" not in line_lower or not any(
+            display_class in line_lower for display_class in _DISPLAY_CLASSES
+        ):
+            continue
+        name = _normalize_lspci_name(line)
+        if name not in seen:
+            names.append(name)
+            seen.add(name)
+    return names
+
+
+def _detect_from_sysfs(drm_path: Path = Path("/sys/class/drm")) -> list[str]:
+    names: list[str] = []
+    seen: set[str] = set()
+    try:
+        cards = sorted(drm_path.glob("card[0-9]*"))
+    except OSError:
+        return []
+
+    for card in cards:
+        device = card / "device"
+        try:
+            vendor = (device / "vendor").read_text().strip().lower()
+        except OSError:
+            continue
+        if vendor != "0x8086":
+            continue
+
+        name = "Intel Integrated Graphics"
+        try:
+            product_name = (device / "product_name").read_text().strip()
+            if product_name:
+                name = product_name
+        except OSError:
+            pass
+
+        if name not in seen:
+            names.append(name)
+            seen.add(name)
+    return names
+
+
+def detect_intel_gpus() -> list[GPUInfo]:
+    """Detect Linux Intel iGPUs. Returns empty list on failure."""
+    names = _detect_from_lspci() or _detect_from_sysfs()
+
+    return [
+        GPUInfo(
+            name=name,
+            vendor="intel",
+            vram_bytes=0,
+        )
+        for name in names
+    ]

--- a/src/whichllm/output/display.py
+++ b/src/whichllm/output/display.py
@@ -163,7 +163,11 @@ def display_hardware(hw: HardwareInfo) -> None:
     # GPUs
     if hw.gpus:
         for i, gpu in enumerate(hw.gpus):
-            vram = _format_bytes(gpu.vram_bytes)
+            vram = (
+                "shared memory"
+                if gpu.vendor == "intel" and gpu.vram_bytes == 0
+                else _format_bytes(gpu.vram_bytes)
+            )
             bw = (
                 f"{gpu.memory_bandwidth_gbps:.0f} GB/s"
                 if gpu.memory_bandwidth_gbps
@@ -181,7 +185,7 @@ def display_hardware(hw: HardwareInfo) -> None:
                 extra.append(f"CUDA {gpu.cuda_version}")
             if gpu.rocm_version:
                 extra.append(f"ROCm {gpu.rocm_version}")
-            if gpu.vendor == "intel":
+            if gpu.vendor == "intel" and gpu.vram_bytes > 0:
                 extra.append("shared memory")
             extra_str = f" ({', '.join(extra)})" if extra else ""
             lines.append(

--- a/src/whichllm/output/display.py
+++ b/src/whichllm/output/display.py
@@ -181,6 +181,8 @@ def display_hardware(hw: HardwareInfo) -> None:
                 extra.append(f"CUDA {gpu.cuda_version}")
             if gpu.rocm_version:
                 extra.append(f"ROCm {gpu.rocm_version}")
+            if gpu.vendor == "intel":
+                extra.append("shared memory")
             extra_str = f" ({', '.join(extra)})" if extra else ""
             lines.append(
                 f"[bold green]GPU {i}:[/] {gpu.name} — {vram}{extra_str} — BW: {bw}"

--- a/tests/test_intel_gpu.py
+++ b/tests/test_intel_gpu.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 import subprocess
+from io import StringIO
+
+from rich.console import Console
 
 from whichllm.hardware import intel
+from whichllm.hardware.types import GPUInfo, HardwareInfo
 
 
 def test_detect_intel_gpu_from_lspci(monkeypatch):
@@ -54,3 +58,31 @@ def test_detect_intel_gpu_from_sysfs_when_lspci_missing(monkeypatch, tmp_path):
     assert gpus[0].vendor == "intel"
     assert gpus[0].vram_bytes == 0
     assert gpus[0].name == "Intel Integrated Graphics"
+
+
+def test_display_intel_shared_memory_without_zero_kb(monkeypatch):
+    from whichllm.output import display as display_mod
+
+    buf = StringIO()
+    monkeypatch.setattr(display_mod, "console", Console(file=buf, force_terminal=False))
+
+    display_mod.display_hardware(
+        HardwareInfo(
+            gpus=[
+                GPUInfo(
+                    name="Alder Lake-P GT1 [UHD Graphics]",
+                    vendor="intel",
+                    vram_bytes=0,
+                )
+            ],
+            cpu_name="CPU",
+            cpu_cores=8,
+            ram_bytes=16 * 1024**3,
+            disk_free_bytes=100 * 1024**3,
+            os="linux",
+        )
+    )
+
+    output = buf.getvalue()
+    assert "shared memory" in output
+    assert "0 KB" not in output

--- a/tests/test_intel_gpu.py
+++ b/tests/test_intel_gpu.py
@@ -1,0 +1,56 @@
+"""Tests for Linux Intel integrated GPU detection."""
+
+from __future__ import annotations
+
+import subprocess
+
+from whichllm.hardware import intel
+
+
+def test_detect_intel_gpu_from_lspci(monkeypatch):
+    output = (
+        '00:02.0 "VGA compatible controller" "Intel Corporation" '
+        '"Alder Lake-P GT1 [UHD Graphics]" -r0c "Dell" "Device 0b19"\n'
+    )
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], 0, stdout=output, stderr="")
+
+    monkeypatch.setattr(intel.subprocess, "run", fake_run)
+
+    gpus = intel.detect_intel_gpus()
+
+    assert len(gpus) == 1
+    assert gpus[0].vendor == "intel"
+    assert gpus[0].vram_bytes == 0
+    assert "UHD Graphics" in gpus[0].name
+
+
+def test_detect_intel_gpu_ignores_non_display_lspci(monkeypatch):
+    output = '00:00.0 "Host bridge" "Intel Corporation" "Device 4621"\n'
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], 0, stdout=output, stderr="")
+
+    monkeypatch.setattr(intel.subprocess, "run", fake_run)
+    monkeypatch.setattr(intel, "_detect_from_sysfs", lambda: [])
+
+    assert intel.detect_intel_gpus() == []
+
+
+def test_detect_intel_gpu_from_sysfs_when_lspci_missing(monkeypatch, tmp_path):
+    card = tmp_path / "card0" / "device"
+    card.mkdir(parents=True)
+    (card / "vendor").write_text("0x8086\n")
+    (card / "uevent").write_text("PCI_SLOT_NAME=0000:00:02.0\n")
+
+    monkeypatch.setattr(intel, "_detect_from_lspci", lambda: [])
+    original_sysfs = intel._detect_from_sysfs
+    monkeypatch.setattr(intel, "_detect_from_sysfs", lambda: original_sysfs(tmp_path))
+
+    gpus = intel.detect_intel_gpus()
+
+    assert len(gpus) == 1
+    assert gpus[0].vendor == "intel"
+    assert gpus[0].vram_bytes == 0
+    assert gpus[0].name == "Intel Integrated Graphics"


### PR DESCRIPTION
## Summary

Adds experimental Linux Intel integrated GPU detection.

This detects Intel integrated GPUs on Linux via `lspci`, with a `/sys/class/drm` fallback, and reports them as `vendor="intel"` instead of falling back to CPU-only mode.

It intentionally does not estimate iGPU memory size or bandwidth yet. Those values vary by system and need real hardware validation.

Fixes #7

## Test

```bash
uv run pytest
```