### PR TITLE
Add nvidia-smi fallback for NVIDIA GPU detection

### DIFF
--- a/src/whichllm/hardware/nvidia.py
+++ b/src/whichllm/hardware/nvidia.py
@@ -1,8 +1,10 @@
-"""NVIDIA GPU detection via pynvml."""
+"""NVIDIA GPU detection via NVML with nvidia-smi fallback."""
 
 from __future__ import annotations
 
 import logging
+import re
+import subprocess
 
 from whichllm.constants import GPU_BANDWIDTH, NVIDIA_COMPUTE_CAPABILITY
 from whichllm.hardware.types import GPUInfo
@@ -27,19 +29,63 @@ def _lookup_bandwidth(name: str) -> float | None:
     return None
 
 
+def _detect_nvidia_gpus_via_smi() -> list[GPUInfo]:
+    """Detect NVIDIA GPUs using nvidia-smi when Python NVML cannot load."""
+    try:
+        result = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=name,memory.total",
+                "--format=csv,noheader,nounits",
+            ],
+            capture_output=True,
+            check=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError, OSError) as e:
+        logger.debug(f"nvidia-smi fallback failed: {e}")
+        return []
+
+    gpus: list[GPUInfo] = []
+    for line in result.stdout.splitlines():
+        parts = [part.strip() for part in line.split(",", maxsplit=1)]
+        if len(parts) != 2 or not parts[0]:
+            continue
+
+        name, memory_mib_text = parts
+        match = re.search(r"\d+", memory_mib_text)
+        if not match:
+            logger.debug(f"Could not parse nvidia-smi memory value: {line!r}")
+            continue
+
+        memory_mib = int(match.group(0))
+        gpus.append(
+            GPUInfo(
+                name=name,
+                vendor="nvidia",
+                vram_bytes=memory_mib * 1024**2,
+                compute_capability=_lookup_compute_capability(name),
+                memory_bandwidth_gbps=_lookup_bandwidth(name),
+            )
+        )
+
+    return gpus
+
+
 def detect_nvidia_gpus() -> list[GPUInfo]:
-    """Detect NVIDIA GPUs using pynvml. Returns empty list on failure."""
+    """Detect NVIDIA GPUs. Returns empty list on failure."""
     try:
         import pynvml
     except ImportError:
-        logger.debug("pynvml not installed, skipping NVIDIA detection")
-        return []
+        logger.debug("pynvml not installed, trying nvidia-smi fallback")
+        return _detect_nvidia_gpus_via_smi()
 
     try:
         pynvml.nvmlInit()
     except pynvml.NVMLError:
-        logger.debug("NVML init failed, no NVIDIA driver available")
-        return []
+        logger.debug("NVML init failed, trying nvidia-smi fallback")
+        return _detect_nvidia_gpus_via_smi()
 
     gpus: list[GPUInfo] = []
     try:
@@ -78,4 +124,8 @@ def detect_nvidia_gpus() -> list[GPUInfo]:
         except Exception:
             pass
 
-    return gpus
+    if gpus:
+        return gpus
+
+    logger.debug("NVML returned no NVIDIA GPUs, trying nvidia-smi fallback")
+    return _detect_nvidia_gpus_via_smi()

--- a/tests/test_nvidia_detection.py
+++ b/tests/test_nvidia_detection.py
@@ -1,0 +1,74 @@
+import builtins
+import subprocess
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from whichllm.hardware.nvidia import detect_nvidia_gpus
+
+
+def test_nvidia_smi_fallback_when_pynvml_missing(monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "pynvml":
+            raise ImportError
+        return real_import(name, *args, **kwargs)
+
+    def fake_run(*args, **kwargs):
+        return SimpleNamespace(stdout="NVIDIA GeForce RTX 5060 Ti, 16303\n")
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    gpus = detect_nvidia_gpus()
+
+    assert len(gpus) == 1
+    assert gpus[0].name == "NVIDIA GeForce RTX 5060 Ti"
+    assert gpus[0].vendor == "nvidia"
+    assert gpus[0].vram_bytes == 16303 * 1024**2
+
+
+def test_nvidia_smi_fallback_when_nvml_init_fails(monkeypatch):
+    class FakeNVMLError(Exception):
+        pass
+
+    fake_pynvml = SimpleNamespace(
+        NVMLError=FakeNVMLError,
+        nvmlInit=Mock(side_effect=FakeNVMLError("NVML unavailable")),
+    )
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "pynvml":
+            return fake_pynvml
+        return real_import(name, *args, **kwargs)
+
+    def fake_run(*args, **kwargs):
+        return SimpleNamespace(stdout="NVIDIA DGX Spark, 128000 MiB\n")
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    gpus = detect_nvidia_gpus()
+
+    assert len(gpus) == 1
+    assert gpus[0].name == "NVIDIA DGX Spark"
+    assert gpus[0].vendor == "nvidia"
+    assert gpus[0].vram_bytes == 128000 * 1024**2
+
+
+def test_nvidia_smi_fallback_returns_empty_on_command_failure(monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "pynvml":
+            raise ImportError
+        return real_import(name, *args, **kwargs)
+
+    def fake_run(*args, **kwargs):
+        raise FileNotFoundError
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert detect_nvidia_gpus() == []


### PR DESCRIPTION
## Summary
- Keep NVML/pynvml as the primary NVIDIA detection path.
- Fall back to `nvidia-smi --query-gpu=name,memory.total --format=csv,noheader,nounits` when pynvml is missing, NVML init fails, or NVML returns no GPUs.
- Add tests for missing pynvml, NVML init failure, and missing `nvidia-smi`.

Fixes #2

## Testing
- Full test suite passed locally on macOS with Python 3.12: `python -m pytest`

## Hardware validation needed
I developed this on macOS, so I could only validate the fallback with mocked `nvidia-smi` output. Please verify on the affected NixOS VM passthrough setup where `nvidia-smi` works but Python NVML fails:

```sh
whichllm hardware
python - <<'PY'
from whichllm.hardware.nvidia import detect_nvidia_gpus
print(detect_nvidia_gpus())
PY
```

Expected: NVIDIA GPU appears instead of `No GPU detected`.

This only validates whichllm's GPU detection path. It does not prove that a downstream inference runtime can use CUDA in that environment.
