### PR TITLE
Handle Strix Halo AMD shared-memory detection and fit

### DIFF
--- a/src/whichllm/cli.py
+++ b/src/whichllm/cli.py
@@ -117,7 +117,11 @@ def _auto_min_params_for_profile(hardware: HardwareInfo, profile: str) -> float 
         return None
     if not hardware.gpus:
         return 2.0  # CPU-only: tiny is the only practical choice
-    best_vram_gb = max(g.vram_bytes for g in hardware.gpus) / (1024**3)
+    usable_ram = int(hardware.ram_bytes * 0.80)
+    best_vram_gb = max(
+        (usable_ram if g.shared_memory and g.vram_bytes == 0 else g.vram_bytes)
+        for g in hardware.gpus
+    ) / (1024**3)
     if best_vram_gb >= 30:
         return 12.0
     if best_vram_gb >= 20:

--- a/src/whichllm/constants.py
+++ b/src/whichllm/constants.py
@@ -2,6 +2,14 @@
 
 _GiB = 1024**3
 
+AMD_SHARED_MEMORY_APU_MARKERS: tuple[str, ...] = (
+    "STRIX HALO",
+    "STRXLGEN",
+    "RADEON 8050S",
+    "RADEON 8060S",
+    "RYZEN AI MAX",
+)
+
 # GPU memory bandwidth in GB/s (theoretical peak)
 # Key: substring matched against GPU name (case-insensitive)
 GPU_BANDWIDTH: dict[str, float] = {
@@ -69,6 +77,13 @@ GPU_BANDWIDTH: dict[str, float] = {
     "RX 6800 XT": 512.0,
     "RX 6800": 512.0,
     "RX 6700 XT": 384.0,
+    # AMD APUs / shared-memory graphics
+    "Ryzen AI MAX+ 395": 256.0,
+    "Ryzen AI MAX 395": 256.0,
+    "Radeon 8060S": 256.0,
+    "Radeon 8050S": 256.0,
+    "Strix Halo": 256.0,
+    "STRXLGEN": 256.0,
     "MI300X": 5300.0,
     "MI250X": 3276.0,
     "MI210": 1638.0,

--- a/src/whichllm/engine/compatibility.py
+++ b/src/whichllm/engine/compatibility.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
+from whichllm.constants import _GiB
 from whichllm.constants import MIN_COMPUTE_CAPABILITY_OLLAMA
 from whichllm.engine.quantization import estimate_weight_bytes
 from whichllm.engine.types import CompatibilityResult
 from whichllm.engine.vram import estimate_vram
 from whichllm.hardware.types import GPUInfo, HardwareInfo
 from whichllm.models.types import GGUFVariant, ModelInfo
+
+
+def _gpu_available_memory(gpu: GPUInfo, usable_ram: int) -> int:
+    if gpu.shared_memory and gpu.vram_bytes < 2 * _GiB:
+        return usable_ram
+    return gpu.vram_bytes
 
 
 def check_compatibility(
@@ -21,15 +28,22 @@ def check_compatibility(
 
     vram_required = estimate_vram(model, variant, context_length)
 
+    # Reserve 20% of RAM for OS and other processes
+    usable_ram = int(hardware.ram_bytes * 0.80)
+
     # Determine best GPU
     best_gpu: GPUInfo | None = None
+    best_gpu_available = 0
     total_vram = 0
     for gpu in hardware.gpus:
-        total_vram += gpu.vram_bytes
-        if best_gpu is None or gpu.vram_bytes > best_gpu.vram_bytes:
+        gpu_available = _gpu_available_memory(gpu, usable_ram)
+        total_vram += gpu_available
+        if best_gpu is None or gpu_available > best_gpu_available:
             best_gpu = gpu
+            best_gpu_available = gpu_available
 
     vram_available = total_vram if total_vram > 0 else 0
+    offload_ram_available = 0 if best_gpu and best_gpu.shared_memory else usable_ram
 
     # Check compute capability for NVIDIA
     if best_gpu and best_gpu.vendor == "nvidia" and best_gpu.compute_capability:
@@ -47,14 +61,13 @@ def check_compatibility(
     if best_gpu and best_gpu.vendor == "apple" and hardware.os != "darwin":
         warnings.append("Metal requires macOS for Apple Silicon inference")
 
-    # Reserve 20% of RAM for OS and other processes
-    usable_ram = int(hardware.ram_bytes * 0.80)
-
     # Determine fit type
     if vram_available >= vram_required:
         fit_type = "full_gpu"
         can_run = True
-    elif vram_available > 0 and (vram_available + usable_ram) >= vram_required:
+    elif (
+        vram_available > 0 and (vram_available + offload_ram_available) >= vram_required
+    ):
         fit_type = "partial_offload"
         can_run = True
         offload_pct = (
@@ -62,7 +75,12 @@ def check_compatibility(
             if vram_required > 0
             else 0
         )
-        warnings.append(f"~{offload_pct:.0f}% of layers will be offloaded to CPU RAM")
+        if best_gpu and best_gpu.shared_memory:
+            warnings.append("Will use shared system memory")
+        else:
+            warnings.append(
+                f"~{offload_pct:.0f}% of layers will be offloaded to CPU RAM"
+            )
     elif usable_ram >= vram_required:
         fit_type = "cpu_only"
         can_run = True

--- a/src/whichllm/engine/performance.py
+++ b/src/whichllm/engine/performance.py
@@ -130,13 +130,15 @@ def estimate_tok_per_sec(
     #   and are read across PCIe at ~1/10th of VRAM bandwidth. With ~40%
     #   of the model offloaded the blended throughput lands near 0.45x.
     # - Apple Silicon: GPU and CPU share one physical unified-memory pool.
+    #   AMD shared-memory APUs such as Strix Halo have the same no-PCIe-cliff
+    #   shape for model weights, even though their backend factor remains AMD.
     #   "Exceeding VRAM" only means exceeding the recommended working set;
     #   the bytes are still read from the same high-bandwidth unified RAM,
     #   so there is no PCIe cliff — only mild OS/cache contention. Using
     #   the discrete 0.45x here was the bug that made DeepSeek-R1-class
     #   models on M2/M3 Ultra report ~1.7 t/s when real-world is 4-15.
     if fit_type == "partial_offload":
-        if gpu.vendor == "apple":
+        if gpu.vendor == "apple" or gpu.shared_memory:
             efficiency *= 0.85
         else:
             efficiency *= 0.45

--- a/src/whichllm/hardware/amd.py
+++ b/src/whichllm/hardware/amd.py
@@ -7,7 +7,7 @@ import logging
 import subprocess
 from pathlib import Path
 
-from whichllm.constants import GPU_BANDWIDTH
+from whichllm.constants import AMD_SHARED_MEMORY_APU_MARKERS, GPU_BANDWIDTH, _GiB
 from whichllm.hardware.types import GPUInfo
 
 logger = logging.getLogger(__name__)
@@ -25,6 +25,34 @@ def _lookup_bandwidth(name: str) -> float | None:
         if key.upper() in name_upper:
             return GPU_BANDWIDTH[key]
     return None
+
+
+def _is_shared_memory_apu(name: str) -> bool:
+    name_upper = name.upper()
+    return any(marker in name_upper for marker in AMD_SHARED_MEMORY_APU_MARKERS)
+
+
+def _normalize_apu_vram(name: str, vram_bytes: int) -> int:
+    if _is_shared_memory_apu(name) and vram_bytes < 2 * _GiB:
+        return 0
+    return vram_bytes
+
+
+def _make_gpu(
+    name: str,
+    *,
+    vram_bytes: int = 0,
+    rocm_version: str | None = None,
+) -> GPUInfo:
+    shared_memory = _is_shared_memory_apu(name)
+    return GPUInfo(
+        name=name,
+        vendor="amd",
+        vram_bytes=_normalize_apu_vram(name, vram_bytes),
+        rocm_version=rocm_version,
+        memory_bandwidth_gbps=_lookup_bandwidth(name),
+        shared_memory=shared_memory,
+    )
 
 
 def _normalize_lspci_name(line: str) -> str:
@@ -109,29 +137,14 @@ def _detect_from_sysfs(drm_path: Path = Path("/sys/class/drm")) -> list[GPUInfo]
         if key in seen:
             continue
         seen.add(key)
-        gpus.append(
-            GPUInfo(
-                name=name,
-                vendor="amd",
-                vram_bytes=vram_bytes,
-                memory_bandwidth_gbps=_lookup_bandwidth(name),
-            )
-        )
+        gpus.append(_make_gpu(name, vram_bytes=vram_bytes))
     return gpus
 
 
 def _detect_amd_gpus_fallback() -> list[GPUInfo]:
     names = _detect_from_lspci()
     if names:
-        return [
-            GPUInfo(
-                name=name,
-                vendor="amd",
-                vram_bytes=0,
-                memory_bandwidth_gbps=_lookup_bandwidth(name),
-            )
-            for name in names
-        ]
+        return [_make_gpu(name) for name in names]
     return _detect_from_sysfs()
 
 
@@ -205,14 +218,6 @@ def detect_amd_gpus() -> list[GPUInfo]:
             except (ValueError, TypeError):
                 pass
 
-        gpus.append(
-            GPUInfo(
-                name=name,
-                vendor="amd",
-                vram_bytes=vram_total,
-                rocm_version=rocm_version,
-                memory_bandwidth_gbps=_lookup_bandwidth(name),
-            )
-        )
+        gpus.append(_make_gpu(name, vram_bytes=vram_total, rocm_version=rocm_version))
 
     return gpus

--- a/src/whichllm/hardware/amd.py
+++ b/src/whichllm/hardware/amd.py
@@ -1,15 +1,22 @@
-"""AMD GPU detection via rocm-smi."""
+"""AMD GPU detection via rocm-smi with Linux fallback probes."""
 
 from __future__ import annotations
 
 import json
 import logging
 import subprocess
+from pathlib import Path
 
 from whichllm.constants import GPU_BANDWIDTH
 from whichllm.hardware.types import GPUInfo
 
 logger = logging.getLogger(__name__)
+
+_DISPLAY_CLASSES = (
+    "vga compatible controller",
+    "3d controller",
+    "display controller",
+)
 
 
 def _lookup_bandwidth(name: str) -> float | None:
@@ -20,8 +27,116 @@ def _lookup_bandwidth(name: str) -> float | None:
     return None
 
 
+def _normalize_lspci_name(line: str) -> str:
+    parts = [p.strip() for p in line.split('"') if p.strip() and p.strip() != "\t"]
+    for i, part in enumerate(parts):
+        if part.lower() in ("advanced micro devices, inc. [amd/ati]", "amd ati"):
+            if i + 1 < len(parts):
+                return parts[i + 1]
+        if "amd" in part.lower() and "ati" in part.lower() and i + 1 < len(parts):
+            return parts[i + 1]
+    return "AMD Graphics"
+
+
+def _detect_from_lspci() -> list[str]:
+    try:
+        result = subprocess.run(
+            ["lspci", "-mm"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        logger.debug("lspci not available or timed out")
+        return []
+
+    if result.returncode != 0:
+        return []
+
+    names: list[str] = []
+    seen: set[str] = set()
+    for line in result.stdout.splitlines():
+        line_lower = line.lower()
+        if not any(vendor in line_lower for vendor in ("amd", "ati")):
+            continue
+        if not any(display_class in line_lower for display_class in _DISPLAY_CLASSES):
+            continue
+        name = _normalize_lspci_name(line)
+        if name not in seen:
+            names.append(name)
+            seen.add(name)
+    return names
+
+
+def _read_int(path: Path) -> int:
+    try:
+        text = path.read_text().strip()
+    except OSError:
+        return 0
+    try:
+        return int(text, 0)
+    except ValueError:
+        return 0
+
+
+def _detect_from_sysfs(drm_path: Path = Path("/sys/class/drm")) -> list[GPUInfo]:
+    gpus: list[GPUInfo] = []
+    seen: set[str] = set()
+    try:
+        cards = sorted(drm_path.glob("card[0-9]*"))
+    except OSError:
+        return []
+
+    for card in cards:
+        device = card / "device"
+        try:
+            vendor = (device / "vendor").read_text().strip().lower()
+        except OSError:
+            continue
+        if vendor != "0x1002":
+            continue
+
+        name = "AMD Graphics"
+        try:
+            product_name = (device / "product_name").read_text().strip()
+            if product_name:
+                name = product_name
+        except OSError:
+            pass
+
+        vram_bytes = _read_int(device / "mem_info_vram_total")
+        key = f"{name}:{vram_bytes}"
+        if key in seen:
+            continue
+        seen.add(key)
+        gpus.append(
+            GPUInfo(
+                name=name,
+                vendor="amd",
+                vram_bytes=vram_bytes,
+                memory_bandwidth_gbps=_lookup_bandwidth(name),
+            )
+        )
+    return gpus
+
+
+def _detect_amd_gpus_fallback() -> list[GPUInfo]:
+    names = _detect_from_lspci()
+    if names:
+        return [
+            GPUInfo(
+                name=name,
+                vendor="amd",
+                vram_bytes=0,
+                memory_bandwidth_gbps=_lookup_bandwidth(name),
+            )
+            for name in names
+        ]
+    return _detect_from_sysfs()
+
+
 def detect_amd_gpus() -> list[GPUInfo]:
-    """Detect AMD GPUs using rocm-smi. Returns empty list on failure."""
+    """Detect AMD GPUs. Returns empty list on failure."""
     gpus: list[GPUInfo] = []
 
     # Get product names
@@ -33,11 +148,11 @@ def detect_amd_gpus() -> list[GPUInfo]:
             timeout=10,
         )
         if result.returncode != 0:
-            return []
+            return _detect_amd_gpus_fallback()
         product_data = json.loads(result.stdout)
     except (FileNotFoundError, subprocess.TimeoutExpired, json.JSONDecodeError):
         logger.debug("rocm-smi not available or failed")
-        return []
+        return _detect_amd_gpus_fallback()
 
     # Get VRAM info
     try:
@@ -48,11 +163,11 @@ def detect_amd_gpus() -> list[GPUInfo]:
             timeout=10,
         )
         if result.returncode != 0:
-            return []
+            return _detect_amd_gpus_fallback()
         mem_data = json.loads(result.stdout)
     except (FileNotFoundError, subprocess.TimeoutExpired, json.JSONDecodeError):
         logger.debug("Failed to get AMD VRAM info")
-        return []
+        return _detect_amd_gpus_fallback()
 
     # Get ROCm version
     rocm_version = None

--- a/src/whichllm/hardware/gpu_simulator.py
+++ b/src/whichllm/hardware/gpu_simulator.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 import re
 
-from whichllm.constants import GPU_BANDWIDTH, _GiB
+from whichllm.constants import AMD_SHARED_MEMORY_APU_MARKERS, GPU_BANDWIDTH, _GiB
 from whichllm.hardware.types import GPUInfo
 
 logger = logging.getLogger(__name__)
@@ -81,6 +81,19 @@ def _lookup_apple_silicon(
             canonical, default_vram = _APPLE_SILICON_CHIPS[key]
             bandwidth = GPU_BANDWIDTH.get(key, 100.0)
             return canonical, "apple", default_vram, bandwidth
+    return None
+
+
+def _is_amd_shared_memory_apu(name: str) -> bool:
+    name_upper = name.upper()
+    return any(marker in name_upper for marker in AMD_SHARED_MEMORY_APU_MARKERS)
+
+
+def _lookup_static_bandwidth(name: str) -> float | None:
+    name_upper = name.upper()
+    for key in sorted(GPU_BANDWIDTH, key=len, reverse=True):
+        if key.upper() in name_upper:
+            return GPU_BANDWIDTH[key]
     return None
 
 
@@ -187,6 +200,8 @@ def create_synthetic_gpu(name: str, vram_override_gb: float | None = None) -> GP
     """
     _last_suggestions.clear()
 
+    amd_shared_memory_apu = _is_amd_shared_memory_apu(name)
+
     # Apple Silicon short-circuit: dbgpu has no Apple entries, so we check
     # first to avoid fuzzy-matching "M1" against "Rage Mobility-M1".
     apple_hit = _lookup_apple_silicon(name)
@@ -219,6 +234,8 @@ def create_synthetic_gpu(name: str, vram_override_gb: float | None = None) -> GP
     bandwidth: float | None = None
     if spec is not None and spec.memory_bandwidth_gb_s:
         bandwidth = spec.memory_bandwidth_gb_s
+    if bandwidth is None:
+        bandwidth = _lookup_static_bandwidth(name)
 
     # Compute capability (CUDA version in dbgpu = compute capability)
     compute_cap: tuple[int, int] | None = None
@@ -229,6 +246,8 @@ def create_synthetic_gpu(name: str, vram_override_gb: float | None = None) -> GP
     vendor = "nvidia"
     if spec is not None:
         vendor = _MANUFACTURER_TO_VENDOR.get(spec.manufacturer, "nvidia")
+    elif amd_shared_memory_apu:
+        vendor = "amd"
 
     display_name = spec.name if spec is not None else name
 
@@ -238,4 +257,5 @@ def create_synthetic_gpu(name: str, vram_override_gb: float | None = None) -> GP
         vram_bytes=vram_bytes,
         compute_capability=compute_cap,
         memory_bandwidth_gbps=bandwidth,
+        shared_memory=amd_shared_memory_apu,
     )

--- a/src/whichllm/hardware/types.py
+++ b/src/whichllm/hardware/types.py
@@ -12,6 +12,7 @@ class GPUInfo:
     cuda_version: str | None = None
     rocm_version: str | None = None
     memory_bandwidth_gbps: float | None = None  # from lookup table
+    shared_memory: bool = False
 
 
 @dataclass

--- a/src/whichllm/output/display.py
+++ b/src/whichllm/output/display.py
@@ -163,11 +163,18 @@ def display_hardware(hw: HardwareInfo) -> None:
     # GPUs
     if hw.gpus:
         for i, gpu in enumerate(hw.gpus):
-            vram = (
-                "shared memory"
-                if gpu.vendor in ("amd", "intel") and gpu.vram_bytes == 0
-                else _format_bytes(gpu.vram_bytes)
-            )
+            if gpu.shared_memory:
+                vram = (
+                    f"{_format_bytes(gpu.vram_bytes)} shared"
+                    if gpu.vram_bytes > 0
+                    else "shared memory"
+                )
+            else:
+                vram = (
+                    "shared memory"
+                    if gpu.vendor in ("amd", "intel") and gpu.vram_bytes == 0
+                    else _format_bytes(gpu.vram_bytes)
+                )
             bw = (
                 f"{gpu.memory_bandwidth_gbps:.0f} GB/s"
                 if gpu.memory_bandwidth_gbps
@@ -185,7 +192,11 @@ def display_hardware(hw: HardwareInfo) -> None:
                 extra.append(f"CUDA {gpu.cuda_version}")
             if gpu.rocm_version:
                 extra.append(f"ROCm {gpu.rocm_version}")
-            if gpu.vendor in ("amd", "intel") and gpu.vram_bytes > 0:
+            if (
+                gpu.vendor in ("amd", "intel")
+                and gpu.vram_bytes > 0
+                and not gpu.shared_memory
+            ):
                 extra.append("shared memory")
             extra_str = f" ({', '.join(extra)})" if extra else ""
             lines.append(
@@ -657,6 +668,7 @@ def display_json(results: list[CompatibilityResult], hardware: HardwareInfo) -> 
                     "vendor": g.vendor,
                     "vram_bytes": g.vram_bytes,
                     "memory_bandwidth_gbps": g.memory_bandwidth_gbps,
+                    "shared_memory": g.shared_memory,
                 }
                 for g in hardware.gpus
             ],

--- a/src/whichllm/output/display.py
+++ b/src/whichllm/output/display.py
@@ -165,7 +165,7 @@ def display_hardware(hw: HardwareInfo) -> None:
         for i, gpu in enumerate(hw.gpus):
             vram = (
                 "shared memory"
-                if gpu.vendor == "intel" and gpu.vram_bytes == 0
+                if gpu.vendor in ("amd", "intel") and gpu.vram_bytes == 0
                 else _format_bytes(gpu.vram_bytes)
             )
             bw = (
@@ -185,7 +185,7 @@ def display_hardware(hw: HardwareInfo) -> None:
                 extra.append(f"CUDA {gpu.cuda_version}")
             if gpu.rocm_version:
                 extra.append(f"ROCm {gpu.rocm_version}")
-            if gpu.vendor == "intel" and gpu.vram_bytes > 0:
+            if gpu.vendor in ("amd", "intel") and gpu.vram_bytes > 0:
                 extra.append("shared memory")
             extra_str = f" ({', '.join(extra)})" if extra else ""
             lines.append(

--- a/tests/test_amd_detection.py
+++ b/tests/test_amd_detection.py
@@ -29,7 +29,47 @@ def test_detect_amd_gpu_from_lspci_when_rocm_smi_missing(monkeypatch):
     assert len(gpus) == 1
     assert gpus[0].vendor == "amd"
     assert gpus[0].vram_bytes == 0
+    assert gpus[0].shared_memory is True
+    assert gpus[0].memory_bandwidth_gbps == 256.0
     assert "Radeon 8060S" in gpus[0].name
+
+
+def test_detect_strix_halo_rocm_smi_does_not_treat_aperture_as_vram(monkeypatch):
+    def fake_run(args, **kwargs):
+        if args[:2] == ["rocm-smi", "--showproductname"]:
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                stdout='{"card0": {"Card SKU": "STRXLGEN"}}',
+                stderr="",
+            )
+        if args[:3] == ["rocm-smi", "--showmeminfo", "vram"]:
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                stdout='{"card0": {"VRAM Total Memory (B)": "536870912"}}',
+                stderr="",
+            )
+        if args[:2] == ["rocm-smi", "--showdriverversion"]:
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                stdout='{"card0": {"Driver version": "7.0.3"}}',
+                stderr="",
+            )
+        raise AssertionError(args)
+
+    monkeypatch.setattr(amd.subprocess, "run", fake_run)
+
+    gpus = amd.detect_amd_gpus()
+
+    assert len(gpus) == 1
+    assert gpus[0].name == "STRXLGEN"
+    assert gpus[0].vendor == "amd"
+    assert gpus[0].shared_memory is True
+    assert gpus[0].vram_bytes == 0
+    assert gpus[0].rocm_version == "7.0.3"
+    assert gpus[0].memory_bandwidth_gbps == 256.0
 
 
 def test_detect_amd_gpu_from_sysfs_when_lspci_missing(monkeypatch, tmp_path):
@@ -49,6 +89,7 @@ def test_detect_amd_gpu_from_sysfs_when_lspci_missing(monkeypatch, tmp_path):
     assert gpus[0].vendor == "amd"
     assert gpus[0].name == "AMD Radeon RX 9060 XT"
     assert gpus[0].vram_bytes == 16 * 1024**3
+    assert gpus[0].shared_memory is False
 
 
 def test_display_amd_shared_memory_without_zero_kb(monkeypatch):
@@ -64,6 +105,7 @@ def test_display_amd_shared_memory_without_zero_kb(monkeypatch):
                     name="Strix Halo [Radeon 8060S]",
                     vendor="amd",
                     vram_bytes=0,
+                    shared_memory=True,
                 )
             ],
             cpu_name="CPU",
@@ -76,4 +118,5 @@ def test_display_amd_shared_memory_without_zero_kb(monkeypatch):
 
     output = buf.getvalue()
     assert "shared memory" in output
+    assert "256 GB/s" not in output
     assert "0 KB" not in output

--- a/tests/test_amd_detection.py
+++ b/tests/test_amd_detection.py
@@ -1,0 +1,79 @@
+"""Tests for AMD GPU detection fallbacks."""
+
+from __future__ import annotations
+
+import subprocess
+from io import StringIO
+
+from rich.console import Console
+
+from whichllm.hardware import amd
+from whichllm.hardware.types import GPUInfo, HardwareInfo
+
+
+def test_detect_amd_gpu_from_lspci_when_rocm_smi_missing(monkeypatch):
+    output = (
+        'c1:00.0 "VGA compatible controller" "Advanced Micro Devices, Inc. '
+        '[AMD/ATI]" "Strix Halo [Radeon 8060S]" -r00 "Framework" "Device 0001"\n'
+    )
+
+    def fake_run(args, **kwargs):
+        if args[0] == "rocm-smi":
+            raise FileNotFoundError
+        return subprocess.CompletedProcess(args, 0, stdout=output, stderr="")
+
+    monkeypatch.setattr(amd.subprocess, "run", fake_run)
+
+    gpus = amd.detect_amd_gpus()
+
+    assert len(gpus) == 1
+    assert gpus[0].vendor == "amd"
+    assert gpus[0].vram_bytes == 0
+    assert "Radeon 8060S" in gpus[0].name
+
+
+def test_detect_amd_gpu_from_sysfs_when_lspci_missing(monkeypatch, tmp_path):
+    card = tmp_path / "card0" / "device"
+    card.mkdir(parents=True)
+    (card / "vendor").write_text("0x1002\n")
+    (card / "product_name").write_text("AMD Radeon RX 9060 XT\n")
+    (card / "mem_info_vram_total").write_text(str(16 * 1024**3))
+
+    monkeypatch.setattr(amd, "_detect_from_lspci", lambda: [])
+    original_sysfs = amd._detect_from_sysfs
+    monkeypatch.setattr(amd, "_detect_from_sysfs", lambda: original_sysfs(tmp_path))
+
+    gpus = amd._detect_amd_gpus_fallback()
+
+    assert len(gpus) == 1
+    assert gpus[0].vendor == "amd"
+    assert gpus[0].name == "AMD Radeon RX 9060 XT"
+    assert gpus[0].vram_bytes == 16 * 1024**3
+
+
+def test_display_amd_shared_memory_without_zero_kb(monkeypatch):
+    from whichllm.output import display as display_mod
+
+    buf = StringIO()
+    monkeypatch.setattr(display_mod, "console", Console(file=buf, force_terminal=False))
+
+    display_mod.display_hardware(
+        HardwareInfo(
+            gpus=[
+                GPUInfo(
+                    name="Strix Halo [Radeon 8060S]",
+                    vendor="amd",
+                    vram_bytes=0,
+                )
+            ],
+            cpu_name="CPU",
+            cpu_cores=16,
+            ram_bytes=128 * 1024**3,
+            disk_free_bytes=100 * 1024**3,
+            os="linux",
+        )
+    )
+
+    output = buf.getvalue()
+    assert "shared memory" in output
+    assert "0 KB" not in output

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -64,6 +64,35 @@ def test_partial_offload():
     assert any("offload" in w.lower() for w in result.warnings)
 
 
+def test_shared_memory_amd_apu_uses_system_memory_pool():
+    model = _make_model(120_000_000_000)
+    variant = _make_variant(55_000_000_000)
+    hw = HardwareInfo(
+        gpus=[
+            GPUInfo(
+                name="STRXLGEN",
+                vendor="amd",
+                vram_bytes=512 * 1024**2,
+                memory_bandwidth_gbps=256.0,
+                shared_memory=True,
+            )
+        ],
+        cpu_name="AMD Ryzen AI MAX+ 395",
+        cpu_cores=16,
+        ram_bytes=128 * 1024**3,
+        disk_free_bytes=200 * 1024**3,
+        os="linux",
+    )
+
+    result = check_compatibility(model, variant, hw)
+
+    assert result.can_run is True
+    assert result.fit_type == "full_gpu"
+    assert result.vram_available_bytes == int(hw.ram_bytes * 0.80)
+    assert not any("offload" in w.lower() for w in result.warnings)
+    assert not any("cpu only" in w.lower() for w in result.warnings)
+
+
 def test_cpu_only():
     model = _make_model(1_000_000_000)
     variant = _make_variant(600_000_000)

--- a/tests/test_gpu_simulator.py
+++ b/tests/test_gpu_simulator.py
@@ -35,6 +35,13 @@ class TestKnownGPULookup:
         assert gpu.vendor == "amd"
         assert gpu.memory_bandwidth_gbps is not None
 
+    def test_amd_strix_halo_with_vram_override(self):
+        gpu = create_synthetic_gpu("Radeon 8060S", vram_override_gb=96)
+        assert gpu.vram_bytes == 96 * _GiB
+        assert gpu.vendor == "amd"
+        assert gpu.shared_memory is True
+        assert gpu.memory_bandwidth_gbps == 256.0
+
     def test_nvidia_gtx_1080(self):
         gpu = create_synthetic_gpu("GTX 1080")
         assert gpu.vram_bytes == 8 * _GiB


### PR DESCRIPTION
## Summary

Adds Linux AMD GPU fallback detection when `rocm-smi` is unavailable.

This uses `lspci -mm` first, then `/sys/class/drm`, so AMD APUs like Strix Halo can show as GPUs instead of CPU-only. Unknown AMD shared-memory size is displayed as `shared memory`.

Fixes #16

## Test

```bash
uv run pytest tests/test_amd_detection.py tests/test_intel_gpu.py
```