### PR TITLE
Fix transformers chat input generation

### DIFF
--- a/src/whichllm/cli.py
+++ b/src/whichllm/cli.py
@@ -732,12 +732,15 @@ while True:
         continue
     messages.append({{"role": "user", "content": user_input}})
     inputs = tokenizer.apply_chat_template(
-        messages, return_tensors="pt", add_generation_prompt=True,
+        messages,
+        return_tensors="pt",
+        return_dict=True,
+        add_generation_prompt=True,
     ).to(model.device)
     streamer = TextIteratorStreamer(tokenizer, skip_prompt=True, skip_special_tokens=True)
     thread = Thread(
         target=model.generate,
-        kwargs=dict(input_ids=inputs, max_new_tokens=512, streamer=streamer),
+        kwargs=dict(**inputs, max_new_tokens=512, streamer=streamer),
     )
     thread.start()
     full = ""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ from whichllm.cli import (
     _auto_min_params_for_profile,
     _current_version,
     _fill_missing_published_at,
+    _generate_chat_script,
     _include_vision_candidates,
     _merge_model_eval_benchmarks,
     _pick_gguf_variant,
@@ -291,6 +292,16 @@ def test_run_exits_gracefully():
             msg in result.stdout
             for msg in ("uv is required", "No model found", "llama-cpp-python")
         )
+
+
+def test_transformers_chat_script_passes_tokenizer_mapping_to_generate():
+    model = _make_model(model_id="org/Test-7B")
+
+    script = _generate_chat_script(model, variant=None, context_length=4096, cpu_only=False)
+
+    assert "return_dict=True" in script
+    assert "kwargs=dict(**inputs, max_new_tokens=512, streamer=streamer)" in script
+    assert "kwargs=dict(input_ids=inputs" not in script
 
 
 def test_snippet_no_model_found():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -297,7 +297,9 @@ def test_run_exits_gracefully():
 def test_transformers_chat_script_passes_tokenizer_mapping_to_generate():
     model = _make_model(model_id="org/Test-7B")
 
-    script = _generate_chat_script(model, variant=None, context_length=4096, cpu_only=False)
+    script = _generate_chat_script(
+        model, variant=None, context_length=4096, cpu_only=False
+    )
 
     assert "return_dict=True" in script
     assert "kwargs=dict(**inputs, max_new_tokens=512, streamer=streamer)" in script


### PR DESCRIPTION
## Summary

Fixes the generated transformers chat script used by `whichllm run`.

The script now asks `apply_chat_template` for a mapping with `return_dict=True` and passes tokenizer outputs into `model.generate(**inputs)`, instead of passing the whole tokenizer result as `input_ids`.

Fixes #15

## Test

```bash
uv run pytest tests/test_cli.py
```