### PR TITLE
Accept Apple-prefixed Silicon GPU aliases

### DIFF
--- a/src/whichllm/hardware/gpu_simulator.py
+++ b/src/whichllm/hardware/gpu_simulator.py
@@ -66,10 +66,14 @@ def _lookup_apple_silicon(
     """Match Apple Silicon chip names. Returns (canonical_name, vendor,
     default_vram_gb, bandwidth_gbps) or None.
 
-    Matches are case-insensitive and accept both "M2 Max" and "m2max" forms.
-    Longest match wins so "M2 Ultra" does not get caught by the "M2" entry.
+    Matches are case-insensitive and accept "M2 Max", "m2max", and
+    display-name forms such as "Apple M2 Max". Longest match wins so
+    "M2 Ultra" does not get caught by the "M2" entry.
     """
     compact = re.sub(r"\s+", "", name).lower()
+    if compact.startswith("apple"):
+        compact = compact.removeprefix("apple")
+
     # Sort keys by length descending so "M2 Ultra" wins over "M2".
     for key in sorted(_APPLE_SILICON_CHIPS, key=len, reverse=True):
         key_compact = re.sub(r"\s+", "", key).lower()

--- a/tests/test_gpu_simulator.py
+++ b/tests/test_gpu_simulator.py
@@ -54,6 +54,34 @@ class TestKnownGPULookup:
         assert "(simulated)" in gpu.name
 
 
+class TestAppleSiliconAliases:
+    @pytest.mark.parametrize(
+        "chip",
+        [
+            "M1",
+            "M1 Max",
+            "M1 Ultra",
+            "M2",
+            "M2 Max",
+            "M2 Ultra",
+            "M3",
+            "M3 Max",
+            "M3 Ultra",
+            "M4",
+            "M4 Max",
+            "M4 Ultra",
+        ],
+    )
+    def test_apple_prefixed_alias_matches_plain_chip_name(self, chip):
+        plain = create_synthetic_gpu(chip)
+        prefixed = create_synthetic_gpu(f"Apple {chip}")
+
+        assert prefixed.name == plain.name
+        assert prefixed.vendor == "apple"
+        assert prefixed.vram_bytes == plain.vram_bytes
+        assert prefixed.memory_bandwidth_gbps == plain.memory_bandwidth_gbps
+
+
 class TestVRAMOverride:
     def test_override_known_gpu(self):
         gpu = create_synthetic_gpu("RTX 4060 Ti", vram_override_gb=16)


### PR DESCRIPTION
## What

Accept Apple-prefixed Apple Silicon names in GPU simulation, so display-name inputs like `Apple M3 Max` resolve the same way as `M3 Max`.

Fixes #23.

## Why

Users often copy the full Apple display name when using `--gpu`. The simulator already has explicit Apple Silicon handling for `M1`-`M4` chip names, but the optional `Apple` prefix caused the lookup to fall through to the discrete GPU database and fail as an unknown GPU.

## Testing

- [x] Tests pass (`pytest`)
- [x] New tests added
- [x] Tested on real hardware

Validation run:

```text
uv run pytest
uv run --with ruff ruff check .
uv run --with ruff ruff format --check .
git diff --check
gitleaks detect --pipe --redact --verbose --no-color
```

Manual repro check:

```text
uv run python -c "from whichllm.hardware.gpu_simulator import create_synthetic_gpu; print(create_synthetic_gpu('Apple M3 Max'))"
```

The manual check now returns `Apple M3 Max (simulated)` with vendor `apple` and the same bandwidth/default memory values as `M3 Max`.

## Notes

This only changes the simulator alias normalization path. It does not change real hardware detection.
