### PR TITLE
Prepare v0.5.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.5.3] - 2026-05-16
+## [0.5.3] - 2026-05-17
 
 ### Added
 
@@ -12,11 +12,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   systems are no longer always treated as CPU-only.
 - NVIDIA `nvidia-smi` fallback detection when pynvml is missing, NVML init
   fails, or NVML reports no devices.
+- Apple-prefixed Apple Silicon simulator aliases, so `--gpu "Apple M3 Max"`
+  resolves the same way as `--gpu "M3 Max"`.
 
 ### Fixed
 
 - `whichllm run` transformers chat generation now passes tokenizer mappings
   into `model.generate(**inputs)`, fixing the `KeyError: 'shape'` crash path.
+- RTX 5060 Ti bandwidth lookup now reports 448 GB/s instead of `N/A`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.5.3] - 2026-05-16
+
+### Added
+
+- Linux Intel integrated GPU detection via `/sys/class/drm`, so Intel iGPU
+  systems are no longer always treated as CPU-only.
+- NVIDIA `nvidia-smi` fallback detection when pynvml is missing, NVML init
+  fails, or NVML reports no devices.
+
+### Fixed
+
+- `whichllm run` transformers chat generation now passes tokenizer mappings
+  into `model.generate(**inputs)`, fixing the `KeyError: 'shape'` crash path.
+
+### Changed
+
+- README install guidance now prefers `uvx` / `uv tool install`.
+- Removed the old marketing note from the repository and added sponsor metadata.
+
 ## [0.5.2] - 2026-05-15
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "whichllm"
-version = "0.5.2"
+version = "0.5.3"
 description = "Find the best LLM that runs on your hardware"
 authors = [{name = "Andyyyy64"}]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -547,7 +547,7 @@ wheels = [
 
 [[package]]
 name = "whichllm"
-version = "0.5.2"
+version = "0.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "dbgpu", extra = ["fuzz"] },


### PR DESCRIPTION
## Summary

- Bump package version to 0.5.3
- Add CHANGELOG entry for the fixes since v0.5.2
- Include the latest Apple Silicon alias and RTX 5060 Ti bandwidth fixes
- Keep uv.lock in sync

## Verification

- `uv run pytest` — 138 passed
- `uv run --with ruff ruff check .` — passed
- `uv run --with ruff ruff format --check .` — passed
- `uv run whichllm --version` — 0.5.3
- `uv run --with build python -m build` — built wheel and sdist

## Release note

A draft GitHub Release can target this branch, but it should only be published after this PR is merged.
