### PR TITLE
fix: add RTX 5060 Ti bandwidth mapping

### DIFF
--- a/src/whichllm/constants.py
+++ b/src/whichllm/constants.py
@@ -10,6 +10,7 @@ GPU_BANDWIDTH: dict[str, float] = {
     "RTX 5080": 960.0,
     "RTX 5070 Ti": 896.0,
     "RTX 5070": 672.0,
+    "RTX 5060 Ti": 448.0,
     # NVIDIA Consumer - RTX 40 series
     "RTX 4090": 1008.0,
     "RTX 4080 SUPER": 736.0,


### PR DESCRIPTION
## Summary
- add RTX 5060 Ti theoretical memory bandwidth mapping
- allow NVIDIA GeForce RTX 5060 Ti to display bandwidth instead of `BW: N/A`
- improve bandwidth-aware speed estimation and ranking on this GPU

## Details
This sets `"RTX 5060 Ti": 448.0` in `GPU_BANDWIDTH`.

Basis:
- 128-bit memory bus
- 28 Gbps GDDR7
- 28 * 128 / 8 = 448 GB/s

## Verification
- `whichllm hardware` should show `BW: 448 GB/s` for RTX 5060 Ti
- rankings/speed estimates should no longer treat bandwidth as unknown for this GPU