### PR TITLE
chore: prepare v0.5.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.5.4] - 2026-05-17
+
+### Fixed
+
+- Strix Halo / Ryzen AI MAX systems are now modeled as AMD shared-memory APUs
+  instead of tiny-VRAM discrete GPUs. `STRXLGEN`, `Radeon 8050S`,
+  `Radeon 8060S`, and related names get a 256 GB/s bandwidth estimate and use
+  the system shared-memory pool for fit checks, avoiding false CPU-only,
+  99%-offload, and `0 tok/s` recommendations.
+
 ## [0.5.3] - 2026-05-17
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "whichllm"
-version = "0.5.3"
+version = "0.5.4"
 description = "Find the best LLM that runs on your hardware"
 authors = [{name = "Andyyyy64"}]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -547,7 +547,7 @@ wheels = [
 
 [[package]]
 name = "whichllm"
-version = "0.5.3"
+version = "0.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "dbgpu", extra = ["fuzz"] },


### PR DESCRIPTION
## What

Prepare the v0.5.4 release after the Strix Halo / Ryzen AI MAX shared-memory APU fix merged in #17.

## Changes

- Bump package version to 0.5.4
- Update uv.lock package metadata
- Add CHANGELOG entry for the Strix Halo shared-memory fix

## Testing

- uv run whichllm --version -> 0.5.4
- uv run --with ruff ruff check .
- uv run --with ruff ruff format --check .
- uv run pytest