### PR TITLE
fix(hardware): stop reporting phantom AMD GPU on Intel-only systems

### DIFF
--- a/src/whichllm/hardware/amd.py
+++ b/src/whichllm/hardware/amd.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import shlex
 import subprocess
 from pathlib import Path
 
@@ -55,17 +56,6 @@ def _make_gpu(
     )
 
 
-def _normalize_lspci_name(line: str) -> str:
-    parts = [p.strip() for p in line.split('"') if p.strip() and p.strip() != "\t"]
-    for i, part in enumerate(parts):
-        if part.lower() in ("advanced micro devices, inc. [amd/ati]", "amd ati"):
-            if i + 1 < len(parts):
-                return parts[i + 1]
-        if "amd" in part.lower() and "ati" in part.lower() and i + 1 < len(parts):
-            return parts[i + 1]
-    return "AMD Graphics"
-
-
 _AMD_VENDOR_MARKERS = (
     "advanced micro devices",
     "amd/ati",
@@ -75,8 +65,9 @@ _AMD_VENDOR_MARKERS = (
 )
 
 
-def _line_has_amd_vendor(line_lower: str) -> bool:
-    return any(marker in line_lower for marker in _AMD_VENDOR_MARKERS)
+def _vendor_is_amd(vendor: str) -> bool:
+    vendor_lower = vendor.lower()
+    return any(marker in vendor_lower for marker in _AMD_VENDOR_MARKERS)
 
 
 def _detect_from_lspci() -> list[str]:
@@ -97,12 +88,23 @@ def _detect_from_lspci() -> list[str]:
     names: list[str] = []
     seen: set[str] = set()
     for line in result.stdout.splitlines():
-        line_lower = line.lower()
-        if not _line_has_amd_vendor(line_lower):
+        # `lspci -mm` is the machine-parsable format:
+        #   <slot> "<class>" "<vendor>" "<device>" [flags] ["<subvendor>" "<subdevice>"]
+        # Parse the quoted columns properly and check the vendor field
+        # specifically, instead of substring-matching the whole line (which
+        # would treat e.g. "Intel Corpor[ati]on" as AMD).
+        try:
+            tokens = shlex.split(line)
+        except ValueError:
             continue
-        if not any(display_class in line_lower for display_class in _DISPLAY_CLASSES):
+        if len(tokens) < 4:
             continue
-        name = _normalize_lspci_name(line)
+        device_class, vendor, device = tokens[1], tokens[2], tokens[3]
+        if device_class.lower() not in _DISPLAY_CLASSES:
+            continue
+        if not _vendor_is_amd(vendor):
+            continue
+        name = device.strip() or "AMD Graphics"
         if name not in seen:
             names.append(name)
             seen.add(name)

--- a/src/whichllm/hardware/amd.py
+++ b/src/whichllm/hardware/amd.py
@@ -66,6 +66,19 @@ def _normalize_lspci_name(line: str) -> str:
     return "AMD Graphics"
 
 
+_AMD_VENDOR_MARKERS = (
+    "advanced micro devices",
+    "amd/ati",
+    "[amd]",
+    "[ati]",
+    "ati technologies",
+)
+
+
+def _line_has_amd_vendor(line_lower: str) -> bool:
+    return any(marker in line_lower for marker in _AMD_VENDOR_MARKERS)
+
+
 def _detect_from_lspci() -> list[str]:
     try:
         result = subprocess.run(
@@ -85,7 +98,7 @@ def _detect_from_lspci() -> list[str]:
     seen: set[str] = set()
     for line in result.stdout.splitlines():
         line_lower = line.lower()
-        if not any(vendor in line_lower for vendor in ("amd", "ati")):
+        if not _line_has_amd_vendor(line_lower):
             continue
         if not any(display_class in line_lower for display_class in _DISPLAY_CLASSES):
             continue

--- a/tests/test_amd_detection.py
+++ b/tests/test_amd_detection.py
@@ -72,6 +72,27 @@ def test_detect_strix_halo_rocm_smi_does_not_treat_aperture_as_vram(monkeypatch)
     assert gpus[0].memory_bandwidth_gbps == 256.0
 
 
+def test_detect_amd_gpu_ignores_intel_only_lspci(monkeypatch):
+    """Regression: an Intel VGA row must not be reported as AMD just
+    because 'Intel Corporation' contains the substring 'ati'."""
+    output = (
+        '00:02.0 "VGA compatible controller" "Intel Corporation" '
+        '"Alder Lake-P GT1 [UHD Graphics]" -r0c -p00 '
+        '"IP3 Tech (HK) Limited" "Device 8027"\n'
+    )
+
+    def fake_run(args, **kwargs):
+        if args[0] == "rocm-smi":
+            raise FileNotFoundError
+        return subprocess.CompletedProcess(args, 0, stdout=output, stderr="")
+
+    monkeypatch.setattr(amd.subprocess, "run", fake_run)
+    # Isolate the lspci path: don't let a real sysfs probe leak in.
+    monkeypatch.setattr(amd, "_detect_from_sysfs", lambda: [])
+
+    assert amd.detect_amd_gpus() == []
+
+
 def test_detect_amd_gpu_from_sysfs_when_lspci_missing(monkeypatch, tmp_path):
     card = tmp_path / "card0" / "device"
     card.mkdir(parents=True)


### PR DESCRIPTION
# Fix: Phantom "AMD Graphics" GPU on Intel-only systems

## Summary

`whichllm hardware` reported a non-existent `AMD Graphics` GPU on systems
that only have an Intel iGPU (no AMD/ATI hardware and no `rocm-smi`
installed).

## Root cause

In `src/whichllm/hardware/amd.py`, the lspci fallback gated AMD lines with
a naive substring check:

```python
if not any(vendor in line_lower for vendor in ("amd", "ati")):
    continue
```

Every line emitted by `lspci -mm` contains the string `Intel Corporation`,
and `"ati"` is a substring of `corpor`**`ati`**`on`. The Intel VGA entry
therefore passed the vendor filter, then `_normalize_lspci_name` fell back
to the literal string `"AMD Graphics"` because no real AMD vendor token was
present.

## Fix

Replace the loose substring check with explicit AMD vendor markers
(`advanced micro devices`, `amd/ati`, `[amd]`, `[ati]`,
`ati technologies`) that only appear in genuine AMD/ATI `lspci` rows.

## Reproduction

Hardware under test: Intel i5-12450H, Intel UHD Graphics (Alder Lake-P GT1),
no discrete GPU, no `rocm-smi`.

### Before the fix (faulty output)

```text
$ uv run whichllm hardware

╭─────────────────────────────── Hardware Info ────────────────────────────────╮
│ GPU 0: AMD Graphics — shared memory — BW: N/A                                │
│ GPU 1: Alder Lake-P GT1 [UHD Graphics] — shared memory — BW: N/A             │
│ CPU: 12th Gen Intel(R) Core(TM) i5-12450H — 8 cores (AVX2)                   │
│ RAM: 15.3 GB                                                                 │
│ Disk free: 177.4 GB                                                          │
│ OS: linux                                                                    │
╰──────────────────────────────────────────────────────────────────────────────╯
```

`GPU 0: AMD Graphics` is a false positive — `lspci` confirms only one
display controller:

```text
$ lspci | grep -iE 'vga|3d|display'
00:02.0 VGA compatible controller: Intel Corporation Alder Lake-P GT1 [UHD Graphics] (rev 0c)
```

### After the fix (correct output)

```text
$ uv run whichllm hardware

╭─────────────────────────────── Hardware Info ────────────────────────────────╮
│ GPU 0: Alder Lake-P GT1 [UHD Graphics] — shared memory — BW: N/A             │
│ CPU: 12th Gen Intel(R) Core(TM) i5-12450H — 8 cores (AVX2)                   │
│ RAM: 15.3 GB                                                                 │
│ Disk free: 177.4 GB                                                          │
│ OS: linux                                                                    │
╰──────────────────────────────────────────────────────────────────────────────╯
```

The phantom AMD entry is gone; only the real Intel iGPU is reported.

## Validation

```text
$ uv run pytest tests/ -x -q
........................................................................ [ 50%]
........................................................................ [100%]
144 passed in 0.66s
```
