### PR TITLE
fix: resolve auto-picked GGUF runtimes

### DIFF
--- a/src/whichllm/cli.py
+++ b/src/whichllm/cli.py
@@ -11,6 +11,7 @@ import typer
 from rich.console import Console
 
 from whichllm.hardware.types import HardwareInfo
+from whichllm.models.types import GGUFVariant, ModelInfo
 
 app = typer.Typer(
     name="llm-checker",
@@ -649,6 +650,81 @@ def _pick_gguf_variant(model, quant_filter: str | None = None):
     return model.gguf_variants[0]
 
 
+def _find_gguf_variant(model: ModelInfo, quant_type: str) -> GGUFVariant | None:
+    for variant in model.gguf_variants:
+        if variant.quant_type.upper() == quant_type.upper():
+            return variant
+    return None
+
+
+def _is_same_model_family(candidate: ModelInfo, selected: ModelInfo) -> bool:
+    if candidate.id == selected.id:
+        return True
+    if candidate.family_id and selected.family_id:
+        if candidate.family_id == selected.family_id:
+            return True
+    if candidate.base_model and candidate.base_model == selected.id:
+        return True
+    if selected.base_model and selected.base_model == candidate.id:
+        return True
+    if candidate.base_model and selected.base_model:
+        return candidate.base_model == selected.base_model
+    return False
+
+
+def _has_compatible_parameter_count(candidate: ModelInfo, selected: ModelInfo) -> bool:
+    if candidate.parameter_count <= 0 or selected.parameter_count <= 0:
+        return True
+    smaller = min(candidate.parameter_count, selected.parameter_count)
+    larger = max(candidate.parameter_count, selected.parameter_count)
+    return (larger / smaller) <= 2.0
+
+
+def _resolve_ranked_gguf_for_run(
+    selected_model: ModelInfo,
+    selected_variant: GGUFVariant,
+    models: list[ModelInfo],
+    quant_filter: str | None = None,
+) -> tuple[ModelInfo, GGUFVariant] | None:
+    """Resolve a ranked GGUF candidate to a real GGUF repo/file for `run`.
+
+    The ranker may synthesize GGUF variants for official safetensors-only repos
+    so they can be scored realistically. `run` cannot execute those synthetic
+    files directly, so it must find a real GGUF sibling before launching.
+    """
+    desired_quant = quant_filter or selected_variant.quant_type
+
+    if selected_model.gguf_variants:
+        variant = _find_gguf_variant(selected_model, desired_quant)
+        return (selected_model, variant) if variant else None
+
+    candidates: list[tuple[bool, int, int, ModelInfo, GGUFVariant]] = []
+    for model in models:
+        if not model.gguf_variants or not _is_same_model_family(model, selected_model):
+            continue
+        if not _has_compatible_parameter_count(model, selected_model):
+            continue
+        variant = _find_gguf_variant(model, desired_quant)
+        if not variant:
+            continue
+        explicit_base = model.base_model == selected_model.id
+        candidates.append(
+            (
+                explicit_base,
+                model.downloads,
+                model.likes,
+                model,
+                variant,
+            )
+        )
+
+    if not candidates:
+        return None
+
+    _, _, _, model, variant = max(candidates, key=lambda item: item[:3])
+    return model, variant
+
+
 def _resolve_model_deps(model, variant) -> tuple[list[str], str]:
     """Determine pip dependencies and script type for a model.
 
@@ -797,6 +873,7 @@ def run(
         models = _load_models(refresh)
         progress.remove_task(task)
 
+    variant = None
     if model_name:
         model = _search_model(models, model_name)
     else:
@@ -820,16 +897,59 @@ def run(
             hardware,
             context_length=context_length,
             top_n=5,
+            quant_filter=quant,
             benchmark_scores=bench_scores,
         )
         if not results:
             console.print("[red]No runnable model found for your hardware.[/]")
             raise typer.Exit(code=1)
-        model = results[0].model
-        if results[0].gguf_variant:
-            quant = quant or results[0].gguf_variant.quant_type
+        skipped_gguf: list[str] = []
+        model = None
+        for ranked in results:
+            if ranked.gguf_variant:
+                resolved = _resolve_ranked_gguf_for_run(
+                    ranked.model,
+                    ranked.gguf_variant,
+                    all_models,
+                    quant_filter=quant,
+                )
+                if resolved:
+                    resolved_model, variant = resolved
+                    if resolved_model.id != ranked.model.id:
+                        console.print(
+                            "[dim]Resolved GGUF runtime: "
+                            f"{ranked.model.id} -> {resolved_model.id} "
+                            f"({variant.quant_type})[/]"
+                        )
+                    model = resolved_model
+                    quant = variant.quant_type
+                    break
+                skipped_gguf.append(ranked.model.id)
+                continue
 
-    variant = _pick_gguf_variant(model, quant)
+            model = ranked.model
+            break
+
+        if skipped_gguf:
+            skipped = ", ".join(skipped_gguf[:3])
+            suffix = "..." if len(skipped_gguf) > 3 else ""
+            console.print(
+                "[yellow]Warning:[/] Skipped GGUF-ranked candidate(s) without "
+                f"a matching runnable GGUF repo: {skipped}{suffix}"
+            )
+        if model is None:
+            console.print(
+                "[red]Error:[/] Top recommendations require GGUF builds, "
+                "but no matching GGUF repos were found."
+            )
+            console.print(
+                "[dim]Try specifying a GGUF model explicitly, for example "
+                "`whichllm run \"qwen gguf\"`.[/]"
+            )
+            raise typer.Exit(code=1)
+
+    if variant is None:
+        variant = _pick_gguf_variant(model, quant)
     deps, script_type = _resolve_model_deps(model, variant)
     script = _generate_chat_script(model, variant, context_length, cpu_only)
 

--- a/src/whichllm/cli.py
+++ b/src/whichllm/cli.py
@@ -944,7 +944,7 @@ def run(
             )
             console.print(
                 "[dim]Try specifying a GGUF model explicitly, for example "
-                "`whichllm run \"qwen gguf\"`.[/]"
+                '`whichllm run "qwen gguf"`.[/]'
             )
             raise typer.Exit(code=1)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 import pytest
 from click.exceptions import Exit
 
+import whichllm.cli as cli_mod
 from whichllm.cli import (
     _auto_min_params_for_profile,
     _current_version,
@@ -11,6 +12,7 @@ from whichllm.cli import (
     _include_vision_candidates,
     _merge_model_eval_benchmarks,
     _pick_gguf_variant,
+    _resolve_ranked_gguf_for_run,
     _resolve_evidence_mode,
     _search_model,
     _validate_evidence,
@@ -280,6 +282,188 @@ def test_pick_gguf_variant_no_variants():
     assert result is None
 
 
+def test_resolve_ranked_synthetic_gguf_to_real_repo():
+    selected = ModelInfo(
+        id="Qwen/Qwen3.6-27B",
+        family_id="qwen3-27b",
+        name="Qwen3.6-27B",
+        parameter_count=27_000_000_000,
+        downloads=50_000,
+    )
+    real_gguf = ModelInfo(
+        id="unsloth/Qwen3.6-27B-GGUF",
+        family_id="qwen3-27b",
+        name="Qwen3.6-27B-GGUF",
+        parameter_count=27_000_000_000,
+        downloads=200_000,
+        base_model="Qwen/Qwen3.6-27B",
+        gguf_variants=[
+            GGUFVariant(
+                filename="Qwen3.6-27B-Q4_K_M.gguf",
+                quant_type="Q4_K_M",
+                file_size_bytes=16_000_000_000,
+            )
+        ],
+    )
+    synthetic = GGUFVariant(
+        filename="Qwen3.6-27B.Q4_K_M.gguf",
+        quant_type="Q4_K_M",
+        file_size_bytes=16_000_000_000,
+    )
+
+    resolved = _resolve_ranked_gguf_for_run(selected, synthetic, [selected, real_gguf])
+
+    assert resolved is not None
+    model, variant = resolved
+    assert model.id == "unsloth/Qwen3.6-27B-GGUF"
+    assert variant.filename == "Qwen3.6-27B-Q4_K_M.gguf"
+
+
+def test_resolve_ranked_synthetic_gguf_prefers_exact_quant():
+    selected = ModelInfo(
+        id="Qwen/Qwen3.6-27B",
+        family_id="qwen3-27b",
+        name="Qwen3.6-27B",
+        parameter_count=27_000_000_000,
+    )
+    q5_only = ModelInfo(
+        id="converter/Qwen3.6-27B-GGUF",
+        family_id="qwen3-27b",
+        name="Qwen3.6-27B-GGUF",
+        parameter_count=27_000_000_000,
+        downloads=1_000_000,
+        gguf_variants=[
+            GGUFVariant(
+                filename="q5.gguf",
+                quant_type="Q5_K_M",
+                file_size_bytes=18_000_000_000,
+            )
+        ],
+    )
+    q4_match = ModelInfo(
+        id="smaller/Qwen3.6-27B-GGUF",
+        family_id="qwen3-27b",
+        name="Qwen3.6-27B-GGUF",
+        parameter_count=27_000_000_000,
+        downloads=10,
+        gguf_variants=[
+            GGUFVariant(
+                filename="q4.gguf",
+                quant_type="Q4_K_M",
+                file_size_bytes=16_000_000_000,
+            )
+        ],
+    )
+    synthetic = GGUFVariant(
+        filename="Qwen3.6-27B.Q4_K_M.gguf",
+        quant_type="Q4_K_M",
+        file_size_bytes=16_000_000_000,
+    )
+
+    resolved = _resolve_ranked_gguf_for_run(
+        selected,
+        synthetic,
+        [selected, q5_only, q4_match],
+    )
+
+    assert resolved is not None
+    model, variant = resolved
+    assert model.id == "smaller/Qwen3.6-27B-GGUF"
+    assert variant.quant_type == "Q4_K_M"
+
+
+def test_resolve_ranked_synthetic_gguf_rejects_quant_mismatch():
+    selected = ModelInfo(
+        id="Qwen/Qwen3.6-27B",
+        family_id="qwen3-27b",
+        name="Qwen3.6-27B",
+        parameter_count=27_000_000_000,
+    )
+    q5_only = ModelInfo(
+        id="converter/Qwen3.6-27B-GGUF",
+        family_id="qwen3-27b",
+        name="Qwen3.6-27B-GGUF",
+        parameter_count=27_000_000_000,
+        downloads=1_000_000,
+        gguf_variants=[
+            GGUFVariant(
+                filename="q5.gguf",
+                quant_type="Q5_K_M",
+                file_size_bytes=18_000_000_000,
+            )
+        ],
+    )
+    synthetic = GGUFVariant(
+        filename="Qwen3.6-27B.Q4_K_M.gguf",
+        quant_type="Q4_K_M",
+        file_size_bytes=16_000_000_000,
+    )
+
+    resolved = _resolve_ranked_gguf_for_run(selected, synthetic, [selected, q5_only])
+
+    assert resolved is None
+
+
+def test_resolve_ranked_synthetic_gguf_without_real_repo_returns_none():
+    selected = ModelInfo(
+        id="Qwen/Qwen3.6-27B",
+        family_id="qwen3-27b",
+        name="Qwen3.6-27B",
+        parameter_count=27_000_000_000,
+    )
+    unrelated = ModelInfo(
+        id="other/Model-7B-GGUF",
+        family_id="model-7b",
+        name="Model-7B-GGUF",
+        parameter_count=7_000_000_000,
+        gguf_variants=[
+            GGUFVariant(
+                filename="other.gguf",
+                quant_type="Q4_K_M",
+                file_size_bytes=4_000_000_000,
+            )
+        ],
+    )
+    synthetic = GGUFVariant(
+        filename="Qwen3.6-27B.Q4_K_M.gguf",
+        quant_type="Q4_K_M",
+        file_size_bytes=16_000_000_000,
+    )
+
+    assert _resolve_ranked_gguf_for_run(selected, synthetic, [selected, unrelated]) is None
+
+
+def test_resolve_ranked_synthetic_gguf_rejects_size_mismatch():
+    selected = ModelInfo(
+        id="deepseek-ai/DeepSeek-V4-Flash",
+        family_id="deepseek-v4-flash",
+        name="DeepSeek-V4-Flash",
+        parameter_count=158_000_000_000,
+    )
+    mtp_head = ModelInfo(
+        id="converter/deepseek-v4-flash-mtp-gguf",
+        family_id="deepseek-v4-flash",
+        name="DeepSeek-V4-Flash-MTP-GGUF",
+        parameter_count=6_600_000_000,
+        gguf_variants=[
+            GGUFVariant(
+                filename="mtp.gguf",
+                quant_type="Q4_K_M",
+                file_size_bytes=4_000_000_000,
+            )
+        ],
+    )
+    synthetic = GGUFVariant(
+        filename="DeepSeek-V4-Flash.Q4_K_M.gguf",
+        quant_type="Q4_K_M",
+        file_size_bytes=90_000_000_000,
+    )
+
+    resolved = _resolve_ranked_gguf_for_run(selected, synthetic, [selected, mtp_head])
+
+    assert resolved is None
+
+
 # --------------- run/snippet command tests ---------------
 
 
@@ -304,6 +488,79 @@ def test_transformers_chat_script_passes_tokenizer_mapping_to_generate():
     assert "return_dict=True" in script
     assert "kwargs=dict(**inputs, max_new_tokens=512, streamer=streamer)" in script
     assert "kwargs=dict(input_ids=inputs" not in script
+
+
+def test_run_auto_pick_resolves_ranked_gguf_before_launch(monkeypatch):
+    selected = ModelInfo(
+        id="Qwen/Qwen3.6-27B",
+        family_id="qwen3-27b",
+        name="Qwen3.6-27B",
+        parameter_count=27_000_000_000,
+        downloads=50_000,
+    )
+    real_gguf = ModelInfo(
+        id="unsloth/Qwen3.6-27B-GGUF",
+        family_id="qwen3-27b",
+        name="Qwen3.6-27B-GGUF",
+        parameter_count=27_000_000_000,
+        downloads=200_000,
+        base_model="Qwen/Qwen3.6-27B",
+        gguf_variants=[
+            GGUFVariant(
+                filename="q4.gguf",
+                quant_type="Q4_K_M",
+                file_size_bytes=16_000_000_000,
+            )
+        ],
+    )
+    synthetic = GGUFVariant(
+        filename="Qwen3.6-27B.Q4_K_M.gguf",
+        quant_type="Q4_K_M",
+        file_size_bytes=16_000_000_000,
+    )
+    captured: dict[str, object] = {}
+
+    def fake_rank_models(models, hardware, **kwargs):
+        captured["quant_filter"] = kwargs.get("quant_filter")
+        return [
+            CompatibilityResult(
+                model=selected,
+                gguf_variant=synthetic,
+                can_run=True,
+                vram_required_bytes=0,
+                vram_available_bytes=0,
+                quality_score=90.0,
+            )
+        ]
+
+    def fake_generate_chat_script(model, variant, context_length, cpu_only):
+        captured["model_id"] = model.id
+        captured["variant"] = variant
+        return "print('ok')"
+
+    class Completed:
+        returncode = 0
+
+    def fake_run(cmd):
+        captured["cmd"] = cmd
+        return Completed()
+
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/uv")
+    monkeypatch.setattr(cli_mod, "_load_models", lambda refresh: [selected, real_gguf])
+    monkeypatch.setattr("whichllm.hardware.detector.detect_hardware", lambda: _hw_with_gpu(8))
+    monkeypatch.setattr("whichllm.models.benchmark.load_benchmark_cache", lambda: {})
+    monkeypatch.setattr("whichllm.engine.ranker.rank_models", fake_rank_models)
+    monkeypatch.setattr(cli_mod, "_generate_chat_script", fake_generate_chat_script)
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    result = CliRunner().invoke(app, ["run", "--quant", "Q4_K_M"])
+
+    assert result.exit_code == 0
+    assert captured["quant_filter"] == "Q4_K_M"
+    assert captured["model_id"] == "unsloth/Qwen3.6-27B-GGUF"
+    assert captured["variant"].filename == "q4.gguf"
+    assert "llama-cpp-python" in captured["cmd"]
+    assert "transformers" not in captured["cmd"]
 
 
 def test_snippet_no_model_found():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -430,7 +430,9 @@ def test_resolve_ranked_synthetic_gguf_without_real_repo_returns_none():
         file_size_bytes=16_000_000_000,
     )
 
-    assert _resolve_ranked_gguf_for_run(selected, synthetic, [selected, unrelated]) is None
+    assert (
+        _resolve_ranked_gguf_for_run(selected, synthetic, [selected, unrelated]) is None
+    )
 
 
 def test_resolve_ranked_synthetic_gguf_rejects_size_mismatch():
@@ -547,7 +549,9 @@ def test_run_auto_pick_resolves_ranked_gguf_before_launch(monkeypatch):
 
     monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/uv")
     monkeypatch.setattr(cli_mod, "_load_models", lambda refresh: [selected, real_gguf])
-    monkeypatch.setattr("whichllm.hardware.detector.detect_hardware", lambda: _hw_with_gpu(8))
+    monkeypatch.setattr(
+        "whichllm.hardware.detector.detect_hardware", lambda: _hw_with_gpu(8)
+    )
     monkeypatch.setattr("whichllm.models.benchmark.load_benchmark_cache", lambda: {})
     monkeypatch.setattr("whichllm.engine.ranker.rank_models", fake_rank_models)
     monkeypatch.setattr(cli_mod, "_generate_chat_script", fake_generate_chat_script)


### PR DESCRIPTION
## Summary
- resolve auto-picked synthetic GGUF candidates to real GGUF repos before running
- keep the runtime quantization aligned with the ranked candidate
- avoid silently falling back to Transformers when a GGUF recommendation was selected
- add regression coverage for GGUF resolution, quant mismatch, size mismatch, and the run flow

## Root cause
The ranker can score official safetensors-only repos with synthetic GGUF variants, but `whichllm run` later tried to execute the original repo. That could turn a GGUF recommendation into a Transformers launch.

Fixes #39

## Check
- uv run pytest -q -s tests/test_cli.py
- uv run pytest -q -s
- uv run whichllm hardware
- ran small GGUF smoke checks with `whichllm run` and exited cleanly