### PR TITLE
Improve MoE speed estimates and show uncertainty

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,10 @@ whichllm snippet "qwen 7b"
 whichllm snippet "llama 3 8b gguf" --quant Q5_K_M
 ```
 
+JSON model rows include `estimated_tok_per_sec`, `speed_confidence`,
+`speed_range_tok_per_sec`, and `speed_notes`. The speed range is a planning
+range, not a live benchmark.
+
 ## Integrations
 
 ### Ollama
@@ -267,7 +271,7 @@ trust, and popularity as adjustments.
 | Quantization | × penalty | Lower-bit quants discounted multiplicatively |
 | Evidence confidence | ×0.55–1.0 | none / self-reported ×0.55, inherited ×0.78, direct full |
 | Runtime fit | ×0.50–1.0 | partial-offload ×0.72, CPU-only ×0.50 |
-| Speed | -8 to +8 | Usability gate vs a fit-dependent tok/s floor |
+| Speed | -8 to +8 | Usability gate vs a fit-dependent tok/s floor; reported with confidence and range metadata |
 | Source trust | -5 to +5 | Official-org bonus, known-repackager penalty |
 | Popularity | tie-breaker | Downloads/likes; weight shrinks as evidence strengthens |
 
@@ -275,6 +279,10 @@ Score markers:
 - **`~`** (yellow) — No direct benchmark; score inherited/interpolated from the model family
 - **`!sr`** (bright yellow) — Uploader-reported benchmark only, not independently verified
 - **`?`** (red) — No benchmark data available
+
+Speed markers in `--status`:
+- **`~`** (yellow) — Estimated tok/s range is available
+- **`?`** (red) — Low-confidence speed estimate; backend/runtime sensitivity is high
 
 ## Documentation
 
@@ -317,7 +325,7 @@ Score markers:
 1. **Hardware detection** — NVIDIA (nvidia-ml-py), AMD (dbgpu/ROCm), Apple Silicon (Metal), CPU cores, RAM, disk
 2. **VRAM estimation** — Weights + KV cache + activation + framework overhead (~500MB)
 3. **Compatibility** — Full GPU / Partial Offload / CPU-only; compute capability and OS checks
-4. **Speed** — tok/s from GPU memory bandwidth lookup (constants.py)
+4. **Speed** — tok/s from GPU memory bandwidth, quantization, backend, fit type, and MoE active parameters
 5. **Scoring** — Benchmark (with confidence dampening), size, quantization penalty, fit type, speed, popularity, source trust (official vs repackager)
 6. **Backend filter** — Apple Silicon and CPU-only restrict to GGUF for stability; Linux+NVIDIA allows AWQ/GPTQ
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -66,6 +66,10 @@ whichllm --cpu-only
 whichllm --json
 ```
 
+JSONの各モデルには `estimated_tok_per_sec` に加えて、
+`speed_confidence`、`speed_range_tok_per_sec`、`speed_notes` が入ります。
+速度は実測値ではなく、ハードウェア情報とモデル情報からの推定です。
+
 ## 主なコマンド
 
 ```bash
@@ -112,7 +116,7 @@ whichllm hardware
 | モデルサイズ | 知識量の近似。MoEは総パラメータを使う |
 | 量子化 | Q4 / Q5 / Q6 / Q8 などの品質低下を反映 |
 | 実行形態 | Full GPU、Partial Offload、CPU-only を区別 |
-| 速度 | tok/s が実用ラインを下回ると減点 |
+| 速度 | tok/s が実用ラインを下回ると減点。表示時は推定の信頼度と幅も出す |
 | 根拠の強さ | direct、base_model、variant、line_interp、self_reported を区別 |
 | 世代補正 | 古い凍結ベンチだけで新世代を上回らないよう調整 |
 
@@ -121,6 +125,11 @@ whichllm hardware
 - `~`: 直接ベンチではなく、系列や派生から推定したスコア
 - `!sr`: アップローダー自己申告の評価値だけに基づくスコア
 - `?`: 利用できるベンチマーク根拠がないスコア
+
+`--status` の速度欄のマーカー:
+
+- `~`: 速度推定の幅がある通常の推定値
+- `?`: backend や runtime の影響が大きい低信頼の推定値
 
 ## 仕組み
 
@@ -131,7 +140,7 @@ whichllm hardware
 3. ベンチマークを読み込みます。現在系の LiveBench / Artificial Analysis /
    Aider / Vision と、凍結系の Arena / Open LLM Leaderboard を分けて扱います。
 4. `base_model` とモデル名からファミリーを作り、同じモデルの派生やGGUFを束ねます。
-5. 候補ごとに VRAM、互換性、速度、スコアを計算します。
+5. 候補ごとに VRAM、互換性、速度、速度推定の信頼度、スコアを計算します。
 6. ファミリーごとに最も良い候補を残して表示します。
 
 キャッシュは `~/.cache/whichllm/` に保存されます。

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -23,7 +23,7 @@ Common options:
 | `--profile` | Ranking profile: `general`, `coding`, `vision`, `math`, `any` |
 | `--evidence` | Benchmark evidence filter: `strict`, `base`, `any` |
 | `--direct` | Alias for `--evidence strict` |
-| `--status` | Show VRAM/RAM, speed, and fit columns instead of published/download columns |
+| `--status` | Show VRAM/RAM, speed, and fit columns instead of published/download columns. Speed may include `~` for estimated range or `?` for low confidence |
 | `--min-params` | Minimum model knowledge capacity in billions of parameters |
 | `--json` | Print machine-readable JSON |
 | `--refresh` | Ignore caches and fetch models/benchmarks again |
@@ -43,6 +43,15 @@ whichllm --evidence strict
 whichllm --status
 whichllm --json | jq '.models[0]'
 ```
+
+Ranking JSON model rows include:
+
+| Field | Meaning |
+| --- | --- |
+| `estimated_tok_per_sec` | Point estimate used by ranking |
+| `speed_confidence` | `high`, `medium`, or `low` |
+| `speed_range_tok_per_sec` | Estimated lower/upper tok/s range, when available |
+| `speed_notes` | Short reasons for the confidence level |
 
 ## `hardware`
 

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -153,7 +153,8 @@ disk space. If the model cannot be downloaded, it is marked unrunnable.
 ## Known limitations
 
 - GPU bandwidth is a lookup or database estimate, not a live benchmark.
-- Speed estimates are order-of-magnitude planning numbers.
+- Speed estimates are planning numbers. Use `--status` or JSON fields such as
+  `speed_confidence` and `speed_range_tok_per_sec` to see uncertainty.
 - Driver, runtime, batch size, prompt length, and thermal limits can change real
   performance.
 - Multi-GPU runtime behavior depends on the inference backend and is only

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -162,7 +162,7 @@ For each candidate variant:
 
 1. Estimate memory.
 2. Check whether it can run.
-3. Estimate tok/s.
+3. Estimate tok/s and attach speed confidence/range metadata.
 4. Resolve benchmark evidence.
 5. Compute a quality score.
 6. Keep the best variant for the model family.
@@ -184,4 +184,6 @@ See [Scoring](scoring.md) for the score details.
 - `upgrade` comparison tables and JSON
 
 Normal ranking tables show published date and downloads. With `--status`, the
-table instead shows memory required, estimated speed, and fit type.
+table instead shows memory required, estimated speed, and fit type. Speed cells
+use `~` for normal estimates with a range and `?` for low-confidence,
+backend-sensitive estimates.

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -133,6 +133,19 @@ After ranking, if any candidate is at least `5 tok/s`, whichllm drops candidates
 below `1.5 tok/s`. This avoids recommending models that technically fit but are
 not practical to use.
 
+The reported speed is a point estimate, not a live benchmark. Ranking also
+exposes speed confidence:
+
+| Confidence | Range factor | Typical cases |
+| --- | ---: | --- |
+| `medium` | `0.60x`-`1.60x` | Normal GPU estimates, synthetic GGUF estimates, AMD shared-memory APU MoE estimates |
+| `low` | `0.35x`-`2.00x` | CPU-only, partial offload, unknown bandwidth, Apple Silicon MoE |
+| `high` | `0.85x`-`1.20x` | Reserved for future measured-speed data |
+
+With `--status`, speed cells use `~` for medium-confidence estimates and `?`
+for low-confidence estimates. JSON exposes the same data as
+`speed_confidence`, `speed_range_tok_per_sec`, and `speed_notes`.
+
 ## Source trust
 
 The source organization contributes a small adjustment:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -163,11 +163,19 @@ Speed is an estimate based on:
 Real performance depends on the inference runtime, driver, prompt length,
 batching, thermal limits, and background memory pressure.
 
-Use `--status` to see the estimate:
+Use `--status` to see the estimate and its confidence marker:
 
 ```bash
 whichllm --status
 ```
+
+Markers in the speed column:
+
+- `~`: estimated speed range is available
+- `?`: low-confidence estimate; runtime/backend differences can be large
+
+JSON includes the same information as `speed_confidence`,
+`speed_range_tok_per_sec`, and `speed_notes`.
 
 ## Apple Silicon partial offload looks different
 

--- a/src/whichllm/engine/performance.py
+++ b/src/whichllm/engine/performance.py
@@ -68,6 +68,18 @@ _MOE_REFERENCE_BANDWIDTH_GBPS = 256.0
 _MOE_MIN_READ_RATIO_AT_REFERENCE = 0.05
 _MOE_MAX_READ_RATIO_FLOOR = 0.25
 
+_SPEED_CONFIDENCE_RANGE_FACTORS: dict[str, tuple[float, float]] = {
+    "high": (0.85, 1.20),
+    "medium": (0.60, 1.60),
+    "low": (0.35, 2.00),
+}
+
+_SPEED_CONFIDENCE_ORDER = {
+    "low": 0,
+    "medium": 1,
+    "high": 2,
+}
+
 
 def _backend_factor(gpu: GPUInfo) -> float:
     if gpu.vendor in _BACKEND_FACTOR:
@@ -103,6 +115,99 @@ def _moe_effective_read_ratio(model: ModelInfo, gpu: GPUInfo) -> float:
     floor = min(_MOE_MAX_READ_RATIO_FLOOR, floor)
 
     return min(1.0, max(active_ratio, floor))
+
+
+def _lower_speed_confidence(current: str, candidate: str) -> str:
+    if _SPEED_CONFIDENCE_ORDER[candidate] < _SPEED_CONFIDENCE_ORDER[current]:
+        return candidate
+    return current
+
+
+def _looks_synthetic_gguf(model: ModelInfo, variant: GGUFVariant | None) -> bool:
+    if variant is None:
+        return False
+    if not variant.filename:
+        return False
+    expected = f"{model.name}.{variant.quant_type}.gguf"
+    return variant.filename == expected
+
+
+def estimate_speed_uncertainty(
+    model: ModelInfo,
+    variant: GGUFVariant | None,
+    gpu: GPUInfo | None,
+    fit_type: str,
+    estimated_tok_per_sec: float | None,
+) -> tuple[str, tuple[float, float] | None, list[str]]:
+    """Return confidence metadata for the speed point estimate.
+
+    The tok/s estimator is intentionally hardware/model-metadata based; it
+    does not know the user's exact llama.cpp, Vulkan, ROCm, Metal, MLX, or
+    runtime kernel versions. This helper keeps that uncertainty visible
+    without mixing it into the ranking score itself.
+    """
+    notes = [
+        "Speed is estimated from memory bandwidth, quantization, backend, and fit type."
+    ]
+    confidence = "medium"
+
+    if estimated_tok_per_sec is None or estimated_tok_per_sec <= 0:
+        return (
+            "low",
+            None,
+            notes + ["No usable bandwidth estimate was available for this setup."],
+        )
+
+    if gpu is None or fit_type == "cpu_only":
+        confidence = "low"
+        notes.append(
+            "CPU-only speed varies heavily with memory channels and BLAS/kernel path."
+        )
+    else:
+        if not gpu.memory_bandwidth_gbps:
+            confidence = "low"
+            notes.append(
+                "GPU memory bandwidth is unknown, so speed is especially uncertain."
+            )
+
+        if fit_type == "partial_offload":
+            confidence = "low"
+            if gpu.vendor == "apple" or gpu.shared_memory:
+                notes.append(
+                    "Partial offload on unified memory is backend-sensitive but avoids a PCIe cliff."
+                )
+            else:
+                notes.append(
+                    "Partial offload on a discrete GPU depends strongly on PCIe and CPU RAM bandwidth."
+                )
+
+        if model.is_moe:
+            notes.append(
+                "MoE speed uses active parameters plus a bandwidth-scaled dispatch/read floor."
+            )
+            if gpu.vendor == "apple":
+                confidence = _lower_speed_confidence(confidence, "low")
+                notes.append(
+                    "Apple Silicon MoE throughput is especially sensitive to Metal/MLX runtime kernels."
+                )
+            elif gpu.vendor == "amd" and gpu.shared_memory:
+                confidence = _lower_speed_confidence(confidence, "medium")
+                notes.append(
+                    "AMD shared-memory APU estimates are calibrated by bandwidth, but ROCm/Vulkan kernels can differ."
+                )
+
+    if _looks_synthetic_gguf(model, variant):
+        confidence = _lower_speed_confidence(confidence, "medium")
+        notes.append(
+            "This is a synthetic GGUF estimate for an official repo, not a measured GGUF file."
+        )
+
+    low_factor, high_factor = _SPEED_CONFIDENCE_RANGE_FACTORS[confidence]
+    speed_range = (
+        round(estimated_tok_per_sec * low_factor, 1),
+        round(estimated_tok_per_sec * high_factor, 1),
+    )
+    return confidence, speed_range, notes
 
 
 def estimate_tok_per_sec(

--- a/src/whichllm/engine/performance.py
+++ b/src/whichllm/engine/performance.py
@@ -59,6 +59,15 @@ _BACKEND_FACTOR: dict[str, float] = {
     "intel": 0.65,
 }
 
+# MoE decode is partly bandwidth-bound and partly kernel/dispatch-bound.
+# The old fixed 25% read floor matched high-bandwidth CUDA cards reasonably
+# well, but badly under-estimated low-bandwidth unified-memory APUs such as
+# Strix Halo where the active expert reads dominate. Model this as a floor
+# that rises with bandwidth: ~5% at 256 GB/s, capped at the legacy 25%.
+_MOE_REFERENCE_BANDWIDTH_GBPS = 256.0
+_MOE_MIN_READ_RATIO_AT_REFERENCE = 0.05
+_MOE_MAX_READ_RATIO_FLOOR = 0.25
+
 
 def _backend_factor(gpu: GPUInfo) -> float:
     if gpu.vendor in _BACKEND_FACTOR:
@@ -71,6 +80,29 @@ def _quant_efficiency(model: ModelInfo, variant: GGUFVariant | None) -> float:
     if not quant:
         return _DEFAULT_QUANT_EFFICIENCY
     return _QUANT_EFFICIENCY.get(quant.upper(), _DEFAULT_QUANT_EFFICIENCY)
+
+
+def _moe_effective_read_ratio(model: ModelInfo, gpu: GPUInfo) -> float:
+    """Return fraction of stored weights read per generated token for MoE."""
+    if not model.is_moe or not model.parameter_count_active:
+        return 1.0
+    if model.parameter_count <= 0:
+        return 1.0
+
+    active_ratio = model.parameter_count_active / model.parameter_count
+    if active_ratio <= 0:
+        return 1.0
+
+    bandwidth = gpu.memory_bandwidth_gbps or 0.0
+    if bandwidth > 0:
+        floor = _MOE_MIN_READ_RATIO_AT_REFERENCE * max(
+            1.0, bandwidth / _MOE_REFERENCE_BANDWIDTH_GBPS
+        )
+    else:
+        floor = _MOE_MAX_READ_RATIO_FLOOR
+    floor = min(_MOE_MAX_READ_RATIO_FLOOR, floor)
+
+    return min(1.0, max(active_ratio, floor))
 
 
 def estimate_tok_per_sec(
@@ -104,14 +136,10 @@ def estimate_tok_per_sec(
 
     model_size = estimate_weight_bytes(model, variant)
 
-    # MoE: only active params need to be read per token. The router itself
-    # also touches the shared layers, so we don't drop fully to the active
-    # ratio.
+    # MoE: use a speed-specific effective read ratio. VRAM fit still uses
+    # total stored weights elsewhere; this only estimates per-token reads.
     if model.is_moe and model.parameter_count_active:
-        active_ratio = model.parameter_count_active / model.parameter_count
-        # Floor at 0.25: shared layers and routing always cost some bandwidth.
-        active_ratio = max(active_ratio, 0.25)
-        effective_read = model_size * active_ratio
+        effective_read = model_size * _moe_effective_read_ratio(model, gpu)
     else:
         effective_read = model_size
 

--- a/src/whichllm/engine/ranker.py
+++ b/src/whichllm/engine/ranker.py
@@ -13,7 +13,7 @@ from whichllm.constants import (
     QUANT_PREFERENCE_ORDER,
 )
 from whichllm.engine.compatibility import check_compatibility
-from whichllm.engine.performance import estimate_tok_per_sec
+from whichllm.engine.performance import estimate_speed_uncertainty, estimate_tok_per_sec
 from whichllm.engine.quantization import effective_quant_type, quant_quality_penalty
 from whichllm.engine.types import CompatibilityResult
 from whichllm.hardware.types import HardwareInfo
@@ -725,6 +725,17 @@ def rank_models(
                     bench_avg = bench_evidence.score * (0.75 + 0.25 * confidence)
 
             compat.estimated_tok_per_sec = tok_per_sec
+            (
+                compat.speed_confidence,
+                compat.speed_range_tok_per_sec,
+                compat.speed_notes,
+            ) = estimate_speed_uncertainty(
+                model,
+                variant,
+                best_gpu,
+                compat.fit_type,
+                tok_per_sec,
+            )
             compat.quality_score = _compute_quality_score(
                 model,
                 variant,

--- a/src/whichllm/engine/types.py
+++ b/src/whichllm/engine/types.py
@@ -13,6 +13,9 @@ class CompatibilityResult:
     vram_required_bytes: int
     vram_available_bytes: int
     estimated_tok_per_sec: float | None = None
+    speed_confidence: str = "medium"  # "high" | "medium" | "low"
+    speed_range_tok_per_sec: tuple[float, float] | None = None
+    speed_notes: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
     quality_score: float = 0.0  # 0-100 for ranking
     fit_type: str = "full_gpu"  # "full_gpu" | "partial_offload" | "cpu_only"

--- a/src/whichllm/models/fetcher.py
+++ b/src/whichllm/models/fetcher.py
@@ -120,6 +120,23 @@ def _extract_size_hint_from_id(model_id: str | None) -> int | None:
     return int(max_b * 1e9)
 
 
+def _extract_active_size_hint_from_id(model_id: str | None) -> int | None:
+    """Extract MoE active parameter hint from names like 35B-A3B."""
+    if not model_id:
+        return None
+    lower = model_id.lower()
+    matches = re.findall(r"\d+(?:\.\d+)?b[-_]?a(\d+(?:\.\d+)?)b", lower)
+    if not matches:
+        return None
+    try:
+        max_b = max(float(m) for m in matches)
+    except ValueError:
+        return None
+    if max_b <= 0:
+        return None
+    return int(max_b * 1e9)
+
+
 def _is_quantized_repo_name(model_id: str) -> bool:
     """Detect quantized/non-base repository naming patterns."""
     lower = model_id.lower()
@@ -135,6 +152,25 @@ def _lookup_curated_count(mapping: dict[str, int], model_id: str) -> int | None:
     for key, value in mapping.items():
         if key.casefold() == model_id_folded:
             return value
+    return None
+
+
+def _resolve_moe_active_params(
+    total_params: int,
+    *model_refs: str | None,
+) -> int | None:
+    """Resolve active params from curated data or A*B naming hints."""
+    for ref in model_refs:
+        if not ref:
+            continue
+        active = _lookup_curated_count(_KNOWN_MOE_ACTIVE_PARAMS, ref)
+        if active and active > 0:
+            return active
+
+    for ref in model_refs:
+        active = _extract_active_size_hint_from_id(ref)
+        if active and active > 0 and (total_params <= 0 or active < total_params):
+            return active
     return None
 
 
@@ -447,10 +483,10 @@ def _parse_model(data: dict) -> ModelInfo | None:
         if isinstance(v, int) and v > experts_per_tok:
             experts_per_tok = v
 
-    # Known-frontier MoE registry: when HF config lacks expert metadata, fall
-    # back to a curated lookup. The total/active values come from each model's
-    # release card.
-    known_moe_active = _lookup_curated_count(_KNOWN_MOE_ACTIVE_PARAMS, model_id)
+    # Known-frontier MoE registry and A*B naming hints: when HF config lacks
+    # expert metadata, fall back to release-card counts or model IDs such as
+    # Qwen3.6-35B-A3B. The A3B suffix means 3B active params per token.
+    known_moe_active = _resolve_moe_active_params(param_count, model_id, base_model)
     is_moe = num_experts > 0 or known_moe_active is not None
     active_params = None
     if is_moe:
@@ -845,7 +881,13 @@ def dicts_to_models(data: list[dict]) -> list[ModelInfo]:
             d["id"],
             base_model,
         )
-        active_params = _lookup_curated_count(_KNOWN_MOE_ACTIVE_PARAMS, d["id"])
+        active_params = _resolve_moe_active_params(
+            param_count,
+            d["id"],
+            base_model,
+            d.get("name"),
+            d.get("architecture"),
+        )
         if active_params is None:
             active_params = d.get("parameter_count_active")
         models.append(

--- a/src/whichllm/models/fetcher.py
+++ b/src/whichllm/models/fetcher.py
@@ -126,14 +126,32 @@ def _is_quantized_repo_name(model_id: str) -> bool:
     return bool(re.search(r"(gptq|awq|bnb|4bit|int4|int8|fp8|gguf|quant)", lower))
 
 
+def _lookup_curated_count(mapping: dict[str, int], model_id: str) -> int | None:
+    value = mapping.get(model_id)
+    if value is not None:
+        return value
+
+    model_id_folded = model_id.casefold()
+    for key, value in mapping.items():
+        if key.casefold() == model_id_folded:
+            return value
+    return None
+
+
 def _normalize_param_count(
     extracted: int,
     model_id: str,
     base_model: str | None,
 ) -> int:
     """Normalize parameter count when metadata is inconsistent."""
+    authoritative = _lookup_curated_count(_AUTHORITATIVE_PARAM_COUNTS, model_id)
+    if authoritative and authoritative > 0:
+        return authoritative
+    known = _lookup_curated_count(_KNOWN_PARAM_COUNTS, model_id)
     if extracted <= 0:
-        return extracted
+        return known or extracted
+    if known and extracted < int(known * 0.35):
+        return known
 
     hints = [
         h
@@ -200,25 +218,25 @@ _KNOWN_MOE_ACTIVE_PARAMS: dict[str, int] = {
     "deepseek-ai/DeepSeek-V3.2-Exp": 37_000_000_000,
     "deepseek-ai/DeepSeek-R1": 37_000_000_000,
     "deepseek-ai/DeepSeek-R1-0528": 37_000_000_000,
-    "deepseek-ai/DeepSeek-V4-Pro": 50_000_000_000,
-    "deepseek-ai/DeepSeek-V4-Flash": 10_000_000_000,
+    "deepseek-ai/DeepSeek-V4-Pro": 49_000_000_000,
+    "deepseek-ai/DeepSeek-V4-Flash": 13_000_000_000,
     "zai-org/GLM-4.5": 32_000_000_000,
     "zai-org/GLM-4.5-Air": 12_000_000_000,
     "zai-org/GLM-4.6": 32_000_000_000,
     "zai-org/GLM-4.7": 32_000_000_000,
     "zai-org/GLM-4.7-Flash": 12_000_000_000,
-    "zai-org/GLM-5": 60_000_000_000,
-    "zai-org/GLM-5-FP8": 60_000_000_000,
-    "zai-org/GLM-5.1": 60_000_000_000,
-    "zai-org/GLM-5.1-FP8": 60_000_000_000,
+    "zai-org/GLM-5": 40_000_000_000,
+    "zai-org/GLM-5-FP8": 40_000_000_000,
+    "zai-org/GLM-5.1": 40_000_000_000,
+    "zai-org/GLM-5.1-FP8": 40_000_000_000,
     "moonshotai/Kimi-K2-Instruct": 32_000_000_000,
     "moonshotai/Kimi-K2-Thinking": 32_000_000_000,
     "MiniMaxAI/MiniMax-M2": 10_000_000_000,
     "MiniMaxAI/MiniMax-M2.5": 10_000_000_000,
-    "XiaomiMiMo/MiMo-V2.5": 7_000_000_000,
-    "XiaomiMiMo/MiMo-V2.5-Pro": 11_000_000_000,
-    "XiaomiMiMo/MiMo-V2-Flash": 3_000_000_000,
-    "google/gemma-4-26b-a4b-it": 4_000_000_000,
+    "XiaomiMiMo/MiMo-V2.5": 15_000_000_000,
+    "XiaomiMiMo/MiMo-V2.5-Pro": 42_000_000_000,
+    "XiaomiMiMo/MiMo-V2-Flash": 15_000_000_000,
+    "google/gemma-4-26B-A4B-it": 3_800_000_000,
     "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16": 3_000_000_000,
     "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8": 3_000_000_000,
     "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16": 12_000_000_000,
@@ -260,25 +278,34 @@ _KNOWN_PARAM_COUNTS: dict[str, int] = {
     "deepseek-ai/DeepSeek-V3-0324": 671_000_000_000,
     "deepseek-ai/DeepSeek-V3.1": 671_000_000_000,
     "deepseek-ai/DeepSeek-V3.2": 685_000_000_000,
-    "deepseek-ai/DeepSeek-V4-Pro": 720_000_000_000,
-    "deepseek-ai/DeepSeek-V4-Flash": 45_000_000_000,
+    "deepseek-ai/DeepSeek-V4-Pro": 1_600_000_000_000,
+    "deepseek-ai/DeepSeek-V4-Flash": 284_000_000_000,
     "moonshotai/Kimi-K2-Instruct": 1_026_000_000_000,
     "moonshotai/Kimi-K2-Thinking": 1_026_000_000_000,
-    "XiaomiMiMo/MiMo-V2.5": 58_000_000_000,
-    "XiaomiMiMo/MiMo-V2.5-Pro": 58_000_000_000,
-    "XiaomiMiMo/MiMo-V2-Flash": 16_000_000_000,
+    "XiaomiMiMo/MiMo-V2.5": 310_000_000_000,
+    "XiaomiMiMo/MiMo-V2.5-Pro": 1_020_000_000_000,
+    "XiaomiMiMo/MiMo-V2-Flash": 309_000_000_000,
     "zai-org/GLM-4.5": 355_000_000_000,
     "zai-org/GLM-4.5-Air": 106_000_000_000,
     "zai-org/GLM-4.6": 355_000_000_000,
     "zai-org/GLM-4.7": 355_000_000_000,
     "zai-org/GLM-4.7-Flash": 30_000_000_000,
-    "zai-org/GLM-5": 754_000_000_000,
-    "zai-org/GLM-5-FP8": 754_000_000_000,
-    "zai-org/GLM-5.1": 754_000_000_000,
-    "zai-org/GLM-5.1-FP8": 754_000_000_000,
+    "zai-org/GLM-5": 744_000_000_000,
+    "zai-org/GLM-5-FP8": 744_000_000_000,
+    "zai-org/GLM-5.1": 744_000_000_000,
+    "zai-org/GLM-5.1-FP8": 744_000_000_000,
     "MiniMaxAI/MiniMax-M2": 230_000_000_000,
     "MiniMaxAI/MiniMax-M2.5": 230_000_000_000,
     "stepfun-ai/Step-3.5-Flash": 30_000_000_000,
+}
+
+# Curated counts that should win even when the HF API exposes safetensors
+# metadata. Some mixed-precision MoEs publish compressed checkpoint tensor
+# counts that are useful for storage inspection but understate the model-card
+# capacity used for ranking, GGUF synthesis, and VRAM planning.
+_AUTHORITATIVE_PARAM_COUNTS: dict[str, int] = {
+    "deepseek-ai/DeepSeek-V4-Pro": 1_600_000_000_000,
+    "deepseek-ai/DeepSeek-V4-Flash": 284_000_000_000,
 }
 
 
@@ -286,15 +313,21 @@ def _extract_param_count(model_data: dict) -> int:
     """Extract parameter count from model data.
 
     Resolution order:
-      1. safetensors metadata (most reliable when present)
-      2. gguf metadata
-      3. config (estimated from hidden_size + num_layers + vocab_size)
-      4. name-based size hint (e.g. ``Qwen/Qwen3-32B`` → 32B)
-      5. ``_KNOWN_PARAM_COUNTS`` lookup (for models like ``microsoft/phi-4``
+      1. authoritative model-card overrides for known mixed-precision MoEs
+      2. safetensors metadata (most reliable when present)
+      3. gguf metadata
+      4. config (estimated from hidden_size + num_layers + vocab_size)
+      5. name-based size hint (e.g. ``Qwen/Qwen3-32B`` → 32B)
+      6. ``_KNOWN_PARAM_COUNTS`` lookup (for models like ``microsoft/phi-4``
          that have neither indexed metadata nor a size in the repo name)
 
     Returns 0 if none of the above succeed (caller drops the model).
     """
+    model_id = model_data.get("id", "") or ""
+    authoritative = _lookup_curated_count(_AUTHORITATIVE_PARAM_COUNTS, model_id)
+    if authoritative and authoritative > 0:
+        return authoritative
+
     # Try safetensors metadata first
     safetensors = model_data.get("safetensors")
     if safetensors and isinstance(safetensors, dict):
@@ -332,8 +365,7 @@ def _extract_param_count(model_data: dict) -> int:
     # ``_KNOWN_PARAM_COUNTS`` is checked *before* the name hint because it
     # is curated: for Llama-4-Scout-17B-16E (16-expert MoE) the name hint
     # gives 17B (the active size) but the actual VRAM footprint is 109B.
-    model_id = model_data.get("id", "") or ""
-    known = _KNOWN_PARAM_COUNTS.get(model_id)
+    known = _lookup_curated_count(_KNOWN_PARAM_COUNTS, model_id)
     if known and known > 0:
         return known
     name_hint = _extract_size_hint_from_id(model_id)
@@ -418,7 +450,7 @@ def _parse_model(data: dict) -> ModelInfo | None:
     # Known-frontier MoE registry: when HF config lacks expert metadata, fall
     # back to a curated lookup. The total/active values come from each model's
     # release card.
-    known_moe_active = _KNOWN_MOE_ACTIVE_PARAMS.get(model_id)
+    known_moe_active = _lookup_curated_count(_KNOWN_MOE_ACTIVE_PARAMS, model_id)
     is_moe = num_experts > 0 or known_moe_active is not None
     active_params = None
     if is_moe:
@@ -677,8 +709,8 @@ async def fetch_models(
             "openai/gpt-oss-20b",
             "google/gemma-3-27b-it",
             "google/gemma-3-12b-it",
-            "google/gemma-4-31b-it",
-            "google/gemma-4-26b-a4b-it",
+            "google/gemma-4-31B-it",
+            "google/gemma-4-26B-A4B-it",
             "meta-llama/Llama-3.3-70B-Instruct",
             "meta-llama/Llama-4-Maverick-17B-128E-Instruct",
             "meta-llama/Llama-4-Scout-17B-16E-Instruct",
@@ -813,15 +845,18 @@ def dicts_to_models(data: list[dict]) -> list[ModelInfo]:
             d["id"],
             base_model,
         )
+        active_params = _lookup_curated_count(_KNOWN_MOE_ACTIVE_PARAMS, d["id"])
+        if active_params is None:
+            active_params = d.get("parameter_count_active")
         models.append(
             ModelInfo(
                 id=d["id"],
                 family_id=d.get("family_id", d["id"]),
                 name=d["name"],
                 parameter_count=param_count,
-                parameter_count_active=d.get("parameter_count_active"),
+                parameter_count_active=active_params,
                 architecture=d.get("architecture", ""),
-                is_moe=d.get("is_moe", False),
+                is_moe=d.get("is_moe", False) or active_params is not None,
                 context_length=d.get("context_length"),
                 license=d.get("license"),
                 published_at=d.get("published_at"),

--- a/src/whichllm/output/display.py
+++ b/src/whichllm/output/display.py
@@ -58,6 +58,18 @@ def _format_published_at(value: str | None) -> str:
         return value[:10] if len(value) >= 10 else value
 
 
+def _format_speed(result: CompatibilityResult) -> str:
+    speed = result.estimated_tok_per_sec
+    if speed is None:
+        return "N/A"
+    base = f"{speed:.1f} tok/s"
+    if result.speed_confidence == "low":
+        return f"[red]{base} ?[/red]"
+    if result.speed_confidence == "medium":
+        return f"[yellow]{base} ~[/yellow]"
+    return base
+
+
 def _parse_published_at(value: str | None) -> datetime | None:
     if not value:
         return None
@@ -264,9 +276,7 @@ def display_ranking(
     for i, r in enumerate(results, 1):
         quant = effective_quant_type(r.model, r.gguf_variant)
         vram_str = _format_bytes(r.vram_required_bytes)
-        speed_str = (
-            f"{r.estimated_tok_per_sec:.1f} tok/s" if r.estimated_tok_per_sec else "N/A"
-        )
+        speed_str = _format_speed(r)
 
         # Score with benchmark status indicator
         score_val = f"{r.quality_score:.1f}"
@@ -338,6 +348,17 @@ def display_ranking(
             parts.append("[red]None / ?[/red] = no benchmark data")
         console.print(f"  [dim]Score:[/dim]  {',  '.join(parts)}")
 
+    if show_status:
+        has_speed_medium = any(r.speed_confidence == "medium" for r in results)
+        has_speed_low = any(r.speed_confidence == "low" for r in results)
+        if has_speed_medium or has_speed_low:
+            parts = []
+            if has_speed_medium:
+                parts.append("[yellow]~[/yellow] = estimated tok/s range")
+            if has_speed_low:
+                parts.append("[red]?[/red] = low-confidence/backend-sensitive tok/s")
+            console.print(f"  [dim]Speed:[/dim]  {',  '.join(parts)}")
+
     has_direct = any(r.benchmark_status == "direct" for r in results)
     if not has_direct:
         console.print(
@@ -377,6 +398,15 @@ def display_ranking(
         joined = ", ".join(f"#{i}" for i in weak_top)
         console.print(
             f"  [yellow]Caution:[/] Weaker benchmark evidence in top ranks: {joined}"
+        )
+
+    weak_speed_top = [
+        idx + 1 for idx, r in enumerate(results[:3]) if r.speed_confidence == "low"
+    ]
+    if weak_speed_top:
+        joined = ", ".join(f"#{i}" for i in weak_speed_top)
+        console.print(
+            f"  [yellow]Speed caution:[/] Low-confidence speed estimates in top ranks: {joined}"
         )
 
     specialized: list[str] = []
@@ -692,6 +722,13 @@ def display_json(results: list[CompatibilityResult], hardware: HardwareInfo) -> 
                 ),
                 "vram_required_bytes": r.vram_required_bytes,
                 "estimated_tok_per_sec": r.estimated_tok_per_sec,
+                "speed_confidence": r.speed_confidence,
+                "speed_range_tok_per_sec": (
+                    list(r.speed_range_tok_per_sec)
+                    if r.speed_range_tok_per_sec
+                    else None
+                ),
+                "speed_notes": r.speed_notes,
                 "quality_score": round(r.quality_score, 2),
                 "benchmark_status": r.benchmark_status,
                 "fit_type": r.fit_type,
@@ -721,6 +758,8 @@ def _summarize_row(name: str, hw: HardwareInfo, results: list) -> dict:
             "top_model": "—",
             "top_quality": 0.0,
             "top_tok_s": 0.0,
+            "top_speed_confidence": "low",
+            "top_speed_range_tok_per_sec": None,
             "top_fit": "—",
             "top_quant": "—",
         }
@@ -732,6 +771,10 @@ def _summarize_row(name: str, hw: HardwareInfo, results: list) -> dict:
         "top_model": r.model.id,
         "top_quality": float(r.quality_score),
         "top_tok_s": float(r.estimated_tok_per_sec),
+        "top_speed_confidence": r.speed_confidence,
+        "top_speed_range_tok_per_sec": (
+            list(r.speed_range_tok_per_sec) if r.speed_range_tok_per_sec else None
+        ),
         "top_fit": r.fit_type,
         "top_quant": (
             r.gguf_variant.quant_type

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -103,6 +103,53 @@ def test_dicts_to_models_uses_case_insensitive_curated_active_params():
     assert models[0].is_moe is True
 
 
+def test_dicts_to_models_recovers_a3b_active_params_from_cached_qwen_model():
+    models = dicts_to_models(
+        [
+            {
+                "id": "Qwen/Qwen3.6-35B-A3B",
+                "family_id": "qwen3.6-35b-a3b",
+                "name": "Qwen3.6-35B-A3B",
+                "parameter_count": 35_951_822_704,
+                "parameter_count_active": None,
+                "architecture": "qwen3_5moe",
+                "downloads": 1,
+                "likes": 1,
+                "gguf_variants": [],
+                "benchmark_scores": {},
+            }
+        ]
+    )
+
+    assert len(models) == 1
+    assert models[0].parameter_count_active == 3_000_000_000
+    assert models[0].is_moe is True
+
+
+def test_dicts_to_models_recovers_a3b_active_params_from_base_model():
+    models = dicts_to_models(
+        [
+            {
+                "id": "local/Qwen36-GGUF",
+                "family_id": "qwen36-gguf",
+                "name": "Qwen36-GGUF",
+                "parameter_count": 34_660_610_688,
+                "parameter_count_active": None,
+                "architecture": "qwen35moe",
+                "downloads": 1,
+                "likes": 1,
+                "gguf_variants": [],
+                "benchmark_scores": {},
+                "base_model": "Qwen/Qwen3.6-35B-A3B",
+            }
+        ]
+    )
+
+    assert len(models) == 1
+    assert models[0].parameter_count_active == 3_000_000_000
+    assert models[0].is_moe is True
+
+
 def test_dicts_to_models_refreshes_stale_xiaomi_moe_cache_counts():
     models = dicts_to_models(
         [
@@ -173,6 +220,26 @@ def test_parse_model_uses_current_glm5_and_xiaomi_active_counts():
     assert glm.parameter_count_active == 40_000_000_000
     assert mimo is not None
     assert mimo.parameter_count_active == 15_000_000_000
+
+
+def test_parse_model_recovers_qwen36_a3b_active_params_from_name():
+    parsed = _parse_model(
+        {
+            "id": "Qwen/Qwen3.6-35B-A3B",
+            "config": {
+                "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+                "model_type": "qwen3_5_moe",
+            },
+            "safetensors": {"total": 35_951_822_704},
+            "siblings": [],
+            "cardData": {},
+        }
+    )
+
+    assert parsed is not None
+    assert parsed.parameter_count == 35_951_822_704
+    assert parsed.parameter_count_active == 3_000_000_000
+    assert parsed.is_moe is True
 
 
 def test_models_cache_roundtrip_keeps_published_at():

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -58,6 +58,123 @@ def test_dicts_to_models_normalizes_cached_parameter_count():
     assert models[0].parameter_count == 27_000_000_000
 
 
+def test_dicts_to_models_refreshes_cached_deepseek_v4_flash_counts():
+    models = dicts_to_models(
+        [
+            {
+                "id": "deepseek-ai/DeepSeek-V4-Flash",
+                "family_id": "deepseek-v4-flash",
+                "name": "DeepSeek-V4-Flash",
+                "parameter_count": 158_069_433_298,
+                "parameter_count_active": 10_000_000_000,
+                "downloads": 1,
+                "likes": 1,
+                "gguf_variants": [],
+                "benchmark_scores": {},
+            }
+        ]
+    )
+
+    assert len(models) == 1
+    assert models[0].parameter_count == 284_000_000_000
+    assert models[0].parameter_count_active == 13_000_000_000
+    assert models[0].is_moe is True
+
+
+def test_dicts_to_models_uses_case_insensitive_curated_active_params():
+    models = dicts_to_models(
+        [
+            {
+                "id": "google/gemma-4-26B-A4B-it",
+                "family_id": "gemma-4-26b-a4b",
+                "name": "gemma-4-26B-A4B-it",
+                "parameter_count": 26_544_131_376,
+                "parameter_count_active": None,
+                "downloads": 1,
+                "likes": 1,
+                "gguf_variants": [],
+                "benchmark_scores": {},
+            }
+        ]
+    )
+
+    assert len(models) == 1
+    assert models[0].parameter_count_active == 3_800_000_000
+    assert models[0].is_moe is True
+
+
+def test_dicts_to_models_refreshes_stale_xiaomi_moe_cache_counts():
+    models = dicts_to_models(
+        [
+            {
+                "id": "XiaomiMiMo/MiMo-V2.5-Pro",
+                "family_id": "mimo-v2.5-pro",
+                "name": "MiMo-V2.5-Pro",
+                "parameter_count": 58_000_000_000,
+                "parameter_count_active": 11_000_000_000,
+                "downloads": 1,
+                "likes": 1,
+                "gguf_variants": [],
+                "benchmark_scores": {},
+            }
+        ]
+    )
+
+    assert len(models) == 1
+    assert models[0].parameter_count == 1_020_000_000_000
+    assert models[0].parameter_count_active == 42_000_000_000
+    assert models[0].is_moe is True
+
+
+def test_dicts_to_models_recovers_missing_known_parameter_count():
+    models = dicts_to_models(
+        [
+            {
+                "id": "zai-org/GLM-5",
+                "family_id": "glm-5",
+                "name": "GLM-5",
+                "parameter_count": 0,
+                "parameter_count_active": None,
+                "downloads": 1,
+                "likes": 1,
+                "gguf_variants": [],
+                "benchmark_scores": {},
+            }
+        ]
+    )
+
+    assert len(models) == 1
+    assert models[0].parameter_count == 744_000_000_000
+    assert models[0].parameter_count_active == 40_000_000_000
+    assert models[0].is_moe is True
+
+
+def test_parse_model_uses_current_glm5_and_xiaomi_active_counts():
+    glm = _parse_model(
+        {
+            "id": "zai-org/GLM-5",
+            "config": {"architectures": ["GlmForCausalLM"]},
+            "safetensors": {"total": 753_864_139_008},
+            "siblings": [],
+            "cardData": {},
+        }
+    )
+    mimo = _parse_model(
+        {
+            "id": "XiaomiMiMo/MiMo-V2-Flash",
+            "config": {"architectures": ["LlamaForCausalLM"]},
+            "safetensors": {"total": 309_785_318_400},
+            "siblings": [],
+            "cardData": {},
+        }
+    )
+
+    assert glm is not None
+    assert glm.parameter_count_active == 40_000_000_000
+    assert mimo is not None
+    assert mimo.parameter_count_active == 15_000_000_000
+
+
 def test_models_cache_roundtrip_keeps_published_at():
     models = [
         ModelInfo(
@@ -182,3 +299,35 @@ def test_parse_model_extracts_hf_eval_benchmark_score():
     )
     assert parsed is not None
     assert parsed.benchmark_scores.get("hf_eval") == 66.4
+
+
+def test_deepseek_v4_flash_uses_model_card_counts_over_hf_tensor_metadata():
+    """DeepSeek V4 Flash's mixed-precision HF tensor metadata reports a
+    smaller stored tensor count than the model-card total. Ranking and GGUF
+    synthesis must use the published model capacity instead."""
+
+    parsed = _parse_model(
+        {
+            "id": "deepseek-ai/DeepSeek-V4-Flash",
+            "config": {
+                "architectures": ["DeepseekV4ForCausalLM"],
+                "model_type": "deepseek_v4",
+                "quantization_config": {"quant_method": "fp8"},
+            },
+            "safetensors": {
+                "total": 158_069_433_298,
+                "parameters": {
+                    "BF16": 1_415_259_264,
+                    "F8_E8M0": 8_858_737_664,
+                    "F8_E4M3": 6_023_020_544,
+                    "I8": 141_733_920_768,
+                },
+            },
+            "siblings": [],
+            "cardData": {},
+        }
+    )
+
+    assert parsed is not None
+    assert parsed.parameter_count == 284_000_000_000
+    assert parsed.parameter_count_active == 13_000_000_000

--- a/tests/test_r3_regressions.py
+++ b/tests/test_r3_regressions.py
@@ -457,3 +457,170 @@ class TestApplePartialOffloadPenalty:
             f"PCIe-bound partial offload at equal bandwidth ({a:.1f} vs "
             f"{n:.1f})"
         )
+
+
+# ----------------------------------------------------------------- R3-8
+
+
+class TestMoESpeedEstimation:
+    """MoE speed estimation should use active params without letting
+    high-bandwidth GPUs turn sparse models into unrealistic outliers."""
+
+    def test_qwen3_next_strix_halo_matches_reported_generation_speed(self):
+        from whichllm.engine.performance import estimate_tok_per_sec
+
+        model = ModelInfo(
+            id="Qwen/Qwen3-Next-80B-A3B-Instruct",
+            family_id="qwen3-next-80b-a3b",
+            name="Qwen3-Next-80B-A3B-Instruct",
+            parameter_count=79_670_000_000,
+            parameter_count_active=3_000_000_000,
+            is_moe=True,
+        )
+        variant = GGUFVariant(
+            filename="qwen3next-q4_k_m.gguf",
+            quant_type="Q4_K_M",
+            file_size_bytes=int(45.17 * 1024**3),
+        )
+        strix_halo = GPUInfo(
+            name="STRXLGEN",
+            vendor="amd",
+            vram_bytes=0,
+            memory_bandwidth_gbps=256.0,
+            shared_memory=True,
+        )
+
+        speed = estimate_tok_per_sec(model, variant, strix_halo, "full_gpu")
+
+        assert 40.0 <= speed <= 50.0
+
+    def test_unknown_ultra_sparse_moe_uses_active_params_on_strix_halo(self):
+        from whichllm.engine.performance import estimate_tok_per_sec
+
+        model = ModelInfo(
+            id="unknown/Experimental-80B-A3B",
+            family_id="experimental-80b-a3b",
+            name="Experimental-80B-A3B",
+            parameter_count=79_670_000_000,
+            parameter_count_active=3_000_000_000,
+            is_moe=True,
+        )
+        variant = GGUFVariant(
+            filename="experimental-q4_k_m.gguf",
+            quant_type="Q4_K_M",
+            file_size_bytes=int(45.17 * 1024**3),
+        )
+        strix_halo = GPUInfo(
+            name="STRXLGEN",
+            vendor="amd",
+            vram_bytes=0,
+            memory_bandwidth_gbps=256.0,
+            shared_memory=True,
+        )
+
+        speed = estimate_tok_per_sec(model, variant, strix_halo, "full_gpu")
+
+        assert 40.0 <= speed <= 50.0
+
+    def test_qwen3_30b_a3b_strix_halo_no_longer_uses_legacy_floor(self):
+        from whichllm.engine.performance import estimate_tok_per_sec
+
+        model = ModelInfo(
+            id="Qwen/Qwen3-30B-A3B",
+            family_id="qwen3-30b-a3b",
+            name="Qwen3-30B-A3B",
+            parameter_count=30_000_000_000,
+            parameter_count_active=3_000_000_000,
+            is_moe=True,
+        )
+        variant = GGUFVariant(
+            filename="qwen3-30b-q4_k_m.gguf",
+            quant_type="Q4_K_M",
+            file_size_bytes=int(17.1 * 1024**3),
+        )
+        strix_halo = GPUInfo(
+            name="STRXLGEN",
+            vendor="amd",
+            vram_bytes=0,
+            memory_bandwidth_gbps=256.0,
+            shared_memory=True,
+        )
+
+        speed = estimate_tok_per_sec(model, variant, strix_halo, "full_gpu")
+
+        assert 50.0 <= speed <= 70.0
+
+    def test_high_bandwidth_gpu_keeps_moe_kernel_floor(self):
+        from whichllm.engine.performance import estimate_tok_per_sec
+
+        model = ModelInfo(
+            id="Qwen/Qwen3-30B-A3B",
+            family_id="qwen3-30b-a3b",
+            name="Qwen3-30B-A3B",
+            parameter_count=30_000_000_000,
+            parameter_count_active=3_000_000_000,
+            is_moe=True,
+        )
+        variant = _gguf("Q5_K_M", 20.6)
+        rtx_4090 = GPUInfo(
+            name="RTX 4090",
+            vendor="nvidia",
+            vram_bytes=24 * 1024**3,
+            compute_capability=(8, 9),
+            memory_bandwidth_gbps=1008.0,
+        )
+
+        speed = estimate_tok_per_sec(model, variant, rtx_4090, "full_gpu")
+
+        assert 100.0 <= speed <= 150.0
+
+    def test_deepseek_v4_flash_synthetic_q4_does_not_fit_strix_halo_96gb(self):
+        deepseek = ModelInfo(
+            id="deepseek-ai/DeepSeek-V4-Flash",
+            family_id="deepseek-v4-flash",
+            name="DeepSeek-V4-Flash",
+            parameter_count=284_000_000_000,
+            parameter_count_active=13_000_000_000,
+            is_moe=True,
+            downloads=1_000_000,
+            gguf_variants=[],
+        )
+        qwen_dense = ModelInfo(
+            id="Qwen/Qwen3.6-27B",
+            family_id="qwen3.6-27b",
+            name="Qwen3.6-27B",
+            parameter_count=27_000_000_000,
+            downloads=100_000,
+            gguf_variants=[],
+        )
+        hardware = HardwareInfo(
+            gpus=[
+                GPUInfo(
+                    name="Strix Halo",
+                    vendor="amd",
+                    vram_bytes=96 * 1024**3,
+                    memory_bandwidth_gbps=256.0,
+                    shared_memory=True,
+                )
+            ],
+            cpu_name="Ryzen AI MAX+ 395",
+            cpu_cores=16,
+            ram_bytes=128 * 1024**3,
+            disk_free_bytes=500 * 1024**3,
+            os="linux",
+        )
+
+        results = rank_models(
+            [deepseek, qwen_dense],
+            hardware,
+            top_n=5,
+            quant_filter="Q4_K_M",
+            benchmark_scores={
+                "deepseek-ai/DeepSeek-V4-Flash": 87.0,
+                "Qwen/Qwen3.6-27B": 84.0,
+            },
+        )
+
+        ids = [r.model.id for r in results]
+        assert "deepseek-ai/DeepSeek-V4-Flash" not in ids
+        assert "Qwen/Qwen3.6-27B" in ids

--- a/tests/test_r3_regressions.py
+++ b/tests/test_r3_regressions.py
@@ -624,3 +624,106 @@ class TestMoESpeedEstimation:
         ids = [r.model.id for r in results]
         assert "deepseek-ai/DeepSeek-V4-Flash" not in ids
         assert "Qwen/Qwen3.6-27B" in ids
+
+
+class TestSpeedUncertainty:
+    def test_strix_halo_moe_speed_is_medium_confidence_with_range(self):
+        from whichllm.engine.performance import estimate_speed_uncertainty
+
+        model = ModelInfo(
+            id="unknown/Experimental-80B-A3B",
+            family_id="experimental-80b-a3b",
+            name="Experimental-80B-A3B",
+            parameter_count=79_670_000_000,
+            parameter_count_active=3_000_000_000,
+            is_moe=True,
+        )
+        variant = GGUFVariant(
+            filename="experimental-q4_k_m.gguf",
+            quant_type="Q4_K_M",
+            file_size_bytes=int(45.17 * 1024**3),
+        )
+        strix_halo = GPUInfo(
+            name="Strix Halo",
+            vendor="amd",
+            vram_bytes=96 * 1024**3,
+            memory_bandwidth_gbps=256.0,
+            shared_memory=True,
+        )
+
+        confidence, speed_range, notes = estimate_speed_uncertainty(
+            model, variant, strix_halo, "full_gpu", 48.0
+        )
+
+        assert confidence == "medium"
+        assert speed_range == (28.8, 76.8)
+        assert any("shared-memory APU" in note for note in notes)
+
+    def test_apple_silicon_moe_speed_is_low_confidence(self):
+        from whichllm.engine.performance import estimate_speed_uncertainty
+
+        model = ModelInfo(
+            id="google/gemma-4-26B-A4B-it",
+            family_id="gemma-4-26b-a4b-it",
+            name="gemma-4-26B-A4B-it",
+            parameter_count=26_000_000_000,
+            parameter_count_active=3_800_000_000,
+            is_moe=True,
+        )
+        variant = _gguf("Q4_K_M", 15.0)
+        apple = GPUInfo(
+            name="M3 Max",
+            vendor="apple",
+            vram_bytes=96 * 1024**3,
+            memory_bandwidth_gbps=400.0,
+            shared_memory=True,
+        )
+
+        confidence, speed_range, notes = estimate_speed_uncertainty(
+            model, variant, apple, "full_gpu", 30.0
+        )
+
+        assert confidence == "low"
+        assert speed_range == (10.5, 60.0)
+        assert any("Metal/MLX" in note for note in notes)
+
+    def test_synthetic_gguf_rank_result_exposes_speed_uncertainty(self):
+        model = ModelInfo(
+            id="Qwen/Qwen3-30B-A3B",
+            family_id="qwen3-30b-a3b",
+            name="Qwen3-30B-A3B",
+            parameter_count=30_000_000_000,
+            parameter_count_active=3_000_000_000,
+            is_moe=True,
+            downloads=1_000_000,
+        )
+        hardware = HardwareInfo(
+            gpus=[
+                GPUInfo(
+                    name="Strix Halo",
+                    vendor="amd",
+                    vram_bytes=96 * 1024**3,
+                    memory_bandwidth_gbps=256.0,
+                    shared_memory=True,
+                )
+            ],
+            cpu_name="Ryzen AI MAX+ 395",
+            cpu_cores=16,
+            ram_bytes=128 * 1024**3,
+            disk_free_bytes=500 * 1024**3,
+            os="linux",
+        )
+
+        result = rank_models(
+            [model],
+            hardware,
+            top_n=1,
+            quant_filter="Q4_K_M",
+            benchmark_scores={"Qwen/Qwen3-30B-A3B": 80.0},
+        )[0]
+
+        assert result.speed_confidence == "medium"
+        assert result.speed_range_tok_per_sec is not None
+        assert result.speed_range_tok_per_sec[0] < result.estimated_tok_per_sec
+        assert result.speed_range_tok_per_sec[1] > result.estimated_tok_per_sec
+        assert any("synthetic GGUF" in note for note in result.speed_notes)


### PR DESCRIPTION
## Summary

- Refresh curated total and active parameter counts for current MoE families.
- Replace the fixed MoE speed floor with a bandwidth-scaled read ratio.
- Expose speed confidence, estimated ranges, and notes in the CLI and JSON output.
- Document the new speed markers and JSON fields.

The old speed path used a fixed 25% MoE read floor. That was too conservative for shared-memory APUs like Strix Halo, where active expert reads dominate, and it hid uncertainty in backend-sensitive cases such as Apple Silicon MoE or partial offload.

Refs #36.

## Output before / after

Command:

```bash
whichllm --gpu "Radeon 8060S" --vram 96 --status --top 5 --quant Q4_K_M --json
```

| Model | main | this branch |
| --- | ---: | ---: |
| Qwen3-Next-80B-A3B | 9.6 tok/s | 48.0 tok/s, medium, 28.8-76.8 |
| gpt-oss-120b | 6.5 tok/s | 32.4 tok/s, medium, 19.5-51.9 |
| Qwen3-30B-A3B | 26.0 tok/s | 65.1 tok/s, medium, 39.0-104.1 |
| Gemma 4 26B A4B | 29.4 tok/s | 51.4 tok/s, medium, 30.8-82.2 |

Command:

```bash
whichllm --gpu "Radeon 8060S" --vram 128 --status --top 5 --quant Q3_K_M --json
```

| Model | main | this branch |
| --- | ---: | ---: |
| DeepSeek-V4-Flash | 3.2 tok/s | 16.1 tok/s, medium, 9.6-25.7 |
| Qwen3-Next-80B-A3B | 11.2 tok/s | 56.1 tok/s, medium, 33.7-89.8 |
| gpt-oss-120b | 7.6 tok/s | 37.9 tok/s, medium, 22.7-60.6 |

Command:

```bash
whichllm --gpu "M3 Ultra" --status --top 5 --quant Q4_K_M --json
```

| Model | main | this branch |
| --- | ---: | ---: |
| Qwen3-Next-80B-A3B | 31.5 tok/s | 50.5 tok/s, low, 17.7-101.0 |
| gpt-oss-120b | 21.3 tok/s | 34.1 tok/s, low, 11.9-68.2 |
| Qwen3-30B-A3B | 85.5 tok/s | 136.8 tok/s, low, 47.9-273.7 |


Command:

```bash
whichllm --gpu "M1 Max" --vram 32 --status --top 50 --quant Q4_K_M --json
```

| Model | main | this branch |
| --- | ---: | ---: |
| Qwen3.6-35B-A3B | 35.7 tok/s, no range | 106.9 tok/s, low, 37.4-213.8 |

Rich output now marks estimated speeds with `~` and low-confidence backend-sensitive speeds with `?`.

## Validation

- `uv run pytest -q -s` -> 165 passed
- `uv run ruff format --check .`
- `git diff --check`
