### PR TITLE
Release v0.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.5.6] - 2026-05-18
+
+### Added
+
+- Speed estimates now include confidence metadata and an estimated tok/s range
+  in table and JSON output, so uncertain backend/model predictions are visible.
+- Windows now has an AMD/Intel GPU detection fallback via
+  `Win32_VideoController`, including 64-bit registry memory reads for GPUs
+  where `AdapterRAM` is capped around 4 GB.
+
+### Fixed
+
+- MoE speed estimates now use active-parameter metadata and a
+  bandwidth-scaled read floor, improving shared-memory APU estimates without
+  over-promoting sparse models on high-bandwidth GPUs.
+- Newer MoE model metadata now recognizes A3B-style active-parameter names.
+- Ryzen AI / Radeon 890M-class Windows iGPUs are modeled as shared-memory AMD
+  GPUs instead of CPU-only or tiny-VRAM discrete GPUs.
+- Mixed dedicated-GPU plus shared-memory-iGPU systems no longer sum unrelated
+  memory pools as one full-GPU target.
+- Windows AMD GPUs no longer receive a misleading ROCm-only warning when
+  Vulkan or DirectML backends may be valid.
+
 ## [0.5.5] - 2026-05-17
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "whichllm"
-version = "0.5.5"
+version = "0.5.6"
 description = "Find the best LLM that runs on your hardware"
 authors = [{name = "Andyyyy64"}]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -547,7 +547,7 @@ wheels = [
 
 [[package]]
 name = "whichllm"
-version = "0.5.5"
+version = "0.5.6"
 source = { editable = "." }
 dependencies = [
     { name = "dbgpu", extra = ["fuzz"] },


### PR DESCRIPTION
## Summary
- Bumps package version to `0.5.6` in `pyproject.toml` and `uv.lock`.
- Adds the `0.5.6` changelog entry.

## Release Notes
- MoE speed estimates now include active-parameter metadata, bandwidth-scaled read floors, confidence labels, and estimated ranges.
- Windows AMD/Intel GPU detection now has a fallback path through `Win32_VideoController` and registry memory reads.
- Ryzen AI / Radeon 890M-class Windows iGPUs are modeled as shared-memory AMD GPUs.
- Mixed dedicated GPU + shared-memory iGPU systems avoid incorrectly summing unrelated memory pools as a single full-GPU target.

## Validation
- `uv lock`
- `uv run --with ruff ruff format --check .`
- `uv run --with ruff ruff check .`
- `.venv/bin/python -m pytest -q -s`
- `uv run whichllm --version`
- `uv run --with build python -m build`
- `git diff --check`

## Issue Scope
- #30 should be covered by the merged Windows GPU detection fallback.
- #5 stays open for the separate `whichllm run` offload-folder crash.
- #44 is a small Apple Silicon follow-up, but it is separate from this release cut.
