### PR TITLE
fix: treat Apple Silicon as shared-memory in fit detection

### DIFF
--- a/src/whichllm/engine/compatibility.py
+++ b/src/whichllm/engine/compatibility.py
@@ -57,7 +57,11 @@ def check_compatibility(
             best_gpu_available = gpu_available
 
     vram_available = total_vram if total_vram > 0 else 0
-    offload_ram_available = 0 if best_gpu and best_gpu.shared_memory else usable_ram
+    offload_ram_available = (
+        0
+        if best_gpu and (best_gpu.shared_memory or best_gpu.vendor == "apple")
+        else usable_ram
+    )
 
     # Check compute capability for NVIDIA
     if best_gpu and best_gpu.vendor == "nvidia" and best_gpu.compute_capability:
@@ -94,7 +98,7 @@ def check_compatibility(
             if vram_required > 0
             else 0
         )
-        if best_gpu and best_gpu.shared_memory:
+        if best_gpu and (best_gpu.shared_memory or best_gpu.vendor == "apple"):
             warnings.append("Will use shared system memory")
         else:
             warnings.append(

--- a/src/whichllm/hardware/apple.py
+++ b/src/whichllm/hardware/apple.py
@@ -60,6 +60,7 @@ def detect_apple_gpu() -> list[GPUInfo]:
                 vendor="apple",
                 vram_bytes=unified_memory,  # unified memory
                 memory_bandwidth_gbps=_lookup_bandwidth(chip_name),
+                shared_memory=True,
             )
         ]
     except (KeyError, IndexError, ValueError) as e:

--- a/src/whichllm/hardware/gpu_simulator.py
+++ b/src/whichllm/hardware/gpu_simulator.py
@@ -213,6 +213,7 @@ def create_synthetic_gpu(name: str, vram_override_gb: float | None = None) -> GP
             vendor=vendor,
             vram_bytes=int(vram_gb * _GiB),
             memory_bandwidth_gbps=bandwidth,
+            shared_memory=True,
         )
 
     spec = _lookup_dbgpu(name)

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -155,6 +155,98 @@ def test_shared_memory_igpu_is_not_summed_with_dedicated_gpu():
     assert any("offloaded to CPU RAM" in w for w in result.warnings)
 
 
+def test_apple_silicon_does_not_double_count_unified_memory():
+    """Apple Silicon uses unified memory: vram_bytes IS the system RAM.
+    The fit checker must not add a separate offload pool on top."""
+    model = _make_model(70_000_000_000)
+    variant = _make_variant(40_000_000_000)  # 40 GB model
+    hw = HardwareInfo(
+        gpus=[
+            GPUInfo(
+                name="Apple M2 Max",
+                vendor="apple",
+                vram_bytes=32 * 1024**3,  # 32 GB unified memory
+                memory_bandwidth_gbps=400.0,
+                shared_memory=True,
+            )
+        ],
+        cpu_name="Apple M2 Max",
+        cpu_cores=12,
+        ram_bytes=32 * 1024**3,
+        disk_free_bytes=200 * 1024**3,
+        os="darwin",
+    )
+
+    result = check_compatibility(model, variant, hw)
+
+    # Model (40 GB) exceeds unified memory (32 GB). There is no separate
+    # CPU RAM pool to spill into, so this must NOT be partial_offload.
+    assert result.fit_type != "partial_offload", (
+        "Apple Silicon should not get partial_offload — unified memory "
+        "cannot be double-counted as GPU VRAM + CPU RAM offload pool"
+    )
+    assert not any("offloaded to CPU RAM" in w for w in result.warnings)
+
+
+def test_apple_silicon_full_gpu_fit():
+    """A model that fits within unified memory should be full_gpu."""
+    model = _make_model(7_000_000_000)
+    variant = _make_variant(4_000_000_000)  # 4 GB model
+    hw = HardwareInfo(
+        gpus=[
+            GPUInfo(
+                name="Apple M4 Pro",
+                vendor="apple",
+                vram_bytes=24 * 1024**3,
+                memory_bandwidth_gbps=273.0,
+                shared_memory=True,
+            )
+        ],
+        cpu_name="Apple M4 Pro",
+        cpu_cores=14,
+        ram_bytes=24 * 1024**3,
+        disk_free_bytes=200 * 1024**3,
+        os="darwin",
+    )
+
+    result = check_compatibility(model, variant, hw)
+
+    assert result.can_run is True
+    assert result.fit_type == "full_gpu"
+    assert not any("offload" in w.lower() for w in result.warnings)
+
+
+def test_apple_silicon_vendor_guard_handles_legacy_shared_memory_false():
+    """Even if a cached/older GPUInfo has shared_memory=False, the
+    vendor=='apple' guard should still prevent double-counting."""
+    model = _make_model(70_000_000_000)
+    variant = _make_variant(40_000_000_000)  # 40 GB model
+    hw = HardwareInfo(
+        gpus=[
+            GPUInfo(
+                name="Apple M2 Max",
+                vendor="apple",
+                vram_bytes=32 * 1024**3,
+                memory_bandwidth_gbps=400.0,
+                shared_memory=False,  # legacy/cached object
+            )
+        ],
+        cpu_name="Apple M2 Max",
+        cpu_cores=12,
+        ram_bytes=32 * 1024**3,
+        disk_free_bytes=200 * 1024**3,
+        os="darwin",
+    )
+
+    result = check_compatibility(model, variant, hw)
+
+    assert result.fit_type != "partial_offload", (
+        "vendor='apple' guard must prevent double-counting even when "
+        "shared_memory=False (cached/older GPUInfo)"
+    )
+    assert not any("offloaded to CPU RAM" in w for w in result.warnings)
+
+
 def test_cpu_only():
     model = _make_model(1_000_000_000)
     variant = _make_variant(600_000_000)

--- a/tests/test_gpu_simulator.py
+++ b/tests/test_gpu_simulator.py
@@ -88,6 +88,11 @@ class TestAppleSiliconAliases:
         assert prefixed.vram_bytes == plain.vram_bytes
         assert prefixed.memory_bandwidth_gbps == plain.memory_bandwidth_gbps
 
+    @pytest.mark.parametrize("chip", ["M1", "M2 Max", "M3 Ultra", "M4 Pro"])
+    def test_apple_silicon_has_shared_memory(self, chip):
+        gpu = create_synthetic_gpu(chip)
+        assert gpu.shared_memory is True
+
 
 class TestVRAMOverride:
     def test_override_known_gpu(self):


### PR DESCRIPTION
## Summary

Apple Silicon uses unified memory, but whichllm was not setting `shared_memory=True` on Apple GPUs. This caused `check_compatibility` to add `usable_ram` as a separate offload pool on top of `vram_bytes`, even though both represent the same physical memory. A 40 GB model on a 32 GB Mac would report `partial_offload` with 57.6 GB phantom available memory instead of correctly reporting that it cannot fit.

## Changes

**apple.py**: Set `shared_memory=True` in the real Apple detector.

**gpu_simulator.py**: Set `shared_memory=True` for simulated Apple Silicon chips (`--gpu "M2 Max"` etc).

**compatibility.py**: Add `vendor == "apple"` guard alongside `shared_memory` checks on the offload pool and partial offload warning, so cached or older GPUInfo objects without the flag are still handled correctly.

**tests**: Added 7 new tests covering the double-counting fix, full_gpu fit, legacy vendor guard, and simulator shared_memory assertion. All 185 tests pass (178 existing + 7 new).

## Behavior change

Before: Apple GPU with 32 GB unified memory treated as 32 GB VRAM + 25.6 GB offload pool = 57.6 GB total. Models that don't actually fit were classified as `partial_offload` with a misleading "layers will be offloaded to CPU RAM" warning.

After: Apple GPU with 32 GB unified memory treated as 32 GB total. No separate offload pool. Models either fit (`full_gpu`) or they don't (`cpu_only`). Speed estimation is unchanged since `performance.py` already handled Apple via vendor check.

Closes #44