### PR TITLE
refactor: fetch benchmark scores concurrently via async sources

### DIFF
--- a/src/whichllm/cli.py
+++ b/src/whichllm/cli.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from importlib.metadata import PackageNotFoundError, version
 from typing import Optional
 
 import typer
@@ -12,6 +11,7 @@ from rich.console import Console
 
 from whichllm.hardware.types import HardwareInfo
 from whichllm.models.types import GGUFVariant, ModelInfo
+from whichllm.utils import _current_version
 
 app = typer.Typer(
     name="llm-checker",
@@ -25,14 +25,6 @@ console = Console()
 def _run_async(coro):
     """Run async coroutine from sync context."""
     return asyncio.run(coro)
-
-
-def _current_version() -> str:
-    """Return installed package version."""
-    try:
-        return version("whichllm")
-    except PackageNotFoundError:
-        return "unknown"
 
 
 def _print_version(value: bool) -> None:
@@ -306,7 +298,7 @@ def main(
         if bench_scores is None:
             try:
                 progress.update(task, description="Fetching benchmark scores...")
-                bench_scores = fetch_benchmark_scores()
+                bench_scores = _run_async(fetch_benchmark_scores())
                 save_benchmark_cache(bench_scores)
             except Exception as e:
                 console.print(f"[yellow]Warning:[/] Benchmark data unavailable: {e}")
@@ -510,7 +502,7 @@ def upgrade(
         bench_scores = None if refresh else load_benchmark_cache()
         if bench_scores is None:
             try:
-                bench_scores = fetch_benchmark_scores()
+                bench_scores = _run_async(fetch_benchmark_scores())
                 save_benchmark_cache(bench_scores)
             except Exception:
                 bench_scores = {}

--- a/src/whichllm/models/benchmark.py
+++ b/src/whichllm/models/benchmark.py
@@ -1,8 +1,8 @@
-"""Benchmark data fetcher: Chatbot Arena ELO + Open LLM Leaderboard."""
+"""Benchmark data fetching."""
 
 from __future__ import annotations
 
-import io
+import asyncio
 import json
 import logging
 import math
@@ -14,77 +14,13 @@ from pathlib import Path
 
 import httpx
 
+from whichllm.utils import _current_version
+
 logger = logging.getLogger(__name__)
 
 CACHE_DIR = Path.home() / ".cache" / "whichllm"
 BENCHMARK_CACHE = CACHE_DIR / "benchmark.json"
 DEFAULT_TTL_SECONDS = 24 * 3600  # 24 hours
-
-# --- Data source URLs ---
-ARENA_ROWS_URL = "https://datasets-server.huggingface.co/rows"
-ARENA_DATASET = "mathewhe/chatbot-arena-elo"
-
-LEADERBOARD_PARQUET_URL = (
-    "https://huggingface.co/api/datasets/open-llm-leaderboard/contents"
-    "/parquet/default/train/0.parquet"
-)
-LEADERBOARD_ROWS_URL = "https://datasets-server.huggingface.co/rows"
-LEADERBOARD_DATASET = "open-llm-leaderboard/contents"
-
-# --- Arena ELO normalization ---
-# Open-source ELO range: ~1030 (worst) to ~1424 (best). Arena is frozen
-# 2025-07-17 (no new models added) so the leaderboard cannot reflect any
-# 2025-Q3+ release; we cap the normalized output at 82 so newer benchmark
-# sources (AA Index / LiveBench, which can reach 95+) decisively win on
-# conflict.
-_ARENA_ELO_MIN = 1030
-_ARENA_ELO_MAX = 1430
-_ARENA_MAX_NORMALIZED = 82.0
-
-# --- Leaderboard normalization ---
-# OLLB v2 averages range ~5 to ~52. The leaderboard is archived 2025-06 with
-# the top slot held by Qwen2.5-32B (47.6 raw = 91.5 if uncapped); capping at
-# 78 prevents an older generation with a strong-but-frozen OLLB score from
-# dominating rankings that now have AA Index / LiveBench coverage too.
-_LB_AVG_MAX = 52
-_OLLB_MAX_NORMALIZED = 78.0
-
-# --- Arena display name -> HuggingFace org mapping ---
-_ARENA_ORG_TO_HF: dict[str, list[str]] = {
-    "Alibaba": ["Qwen"],
-    "Meta": ["meta-llama"],
-    "DeepSeek": ["deepseek-ai"],
-    "DeepSeek AI": ["deepseek-ai"],
-    "Google": ["google"],
-    "Mistral": ["mistralai"],
-    "Microsoft": ["microsoft"],
-    "Nvidia": ["nvidia"],
-    "01 AI": ["01-ai"],
-    "Allen AI": ["allenai"],
-    "Ai2": ["allenai"],
-    "AllenAI/UW": ["allenai"],
-    "Cohere": ["CohereForAI"],
-    "HuggingFace": ["HuggingFaceH4", "huggingface"],
-    "AI21 Labs": ["ai21labs"],
-    "NousResearch": ["NousResearch"],
-    "NexusFlow": ["Nexusflow"],
-    "Princeton": ["princeton-nlp"],
-    "IBM": ["ibm-granite"],
-    "InternLM": ["internlm"],
-    "Together AI": ["togethercomputer"],
-    "TII": ["tiiuae"],
-    "MiniMax": ["MiniMaxAI"],
-    "MosaicML": ["mosaicml"],
-    "Databricks": ["databricks"],
-    "Moonshot": ["moonshotai"],
-    "UC Berkeley": ["berkeley-nest"],
-    "Cognitive Computations": ["cognitivecomputations"],
-    "Upstage AI": ["upstage"],
-    "UW": ["timdettmers"],
-    "Snowflake": ["Snowflake"],
-    "LMSYS": ["lmsys"],
-    "OpenChat": ["openchat"],
-}
 
 
 @dataclass(frozen=True)
@@ -127,150 +63,6 @@ def save_benchmark_cache(scores: dict[str, float]) -> None:
     data = {"cached_at": time.time(), "scores": scores}
     BENCHMARK_CACHE.write_text(json.dumps(data, ensure_ascii=False))
     logger.debug(f"Saved {len(scores)} benchmark scores to cache")
-
-
-def _normalize_arena_elo(elo: float) -> float:
-    """Normalize Arena ELO to a frozen-source-aware 0-_ARENA_MAX_NORMALIZED scale."""
-    score = (
-        (elo - _ARENA_ELO_MIN)
-        / (_ARENA_ELO_MAX - _ARENA_ELO_MIN)
-        * _ARENA_MAX_NORMALIZED
-    )
-    return max(0.0, min(_ARENA_MAX_NORMALIZED, round(score, 1)))
-
-
-def _normalize_leaderboard_avg(avg: float) -> float:
-    """Normalize Open LLM Leaderboard average to 0-_OLLB_MAX_NORMALIZED scale."""
-    score = avg / _LB_AVG_MAX * _OLLB_MAX_NORMALIZED
-    return max(0.0, min(_OLLB_MAX_NORMALIZED, round(score, 1)))
-
-
-def _arena_name_to_hf_ids(model_name: str, org: str) -> list[str]:
-    """Convert Arena display name to potential HuggingFace model IDs."""
-    hf_orgs = _ARENA_ORG_TO_HF.get(org, [])
-    candidates = []
-
-    # Clean the model name: remove date suffixes like "(03-2025)"
-    clean_name = re.sub(r"\s*\([\d-]+\)\s*$", "", model_name).strip()
-    # Remove -bf16, -fp8 suffixes for base matching
-    base_name = re.sub(r"-(bf16|fp8|fp16)$", "", clean_name, flags=re.IGNORECASE)
-
-    for hf_org in hf_orgs:
-        candidates.append(f"{hf_org}/{clean_name}")
-        if base_name != clean_name:
-            candidates.append(f"{hf_org}/{base_name}")
-        # Try with -Instruct suffix stripped for base model matching
-        no_instruct = re.sub(r"-Instruct$", "", clean_name)
-        if no_instruct != clean_name:
-            candidates.append(f"{hf_org}/{no_instruct}")
-
-    return candidates
-
-
-def _fetch_arena_scores(client: httpx.Client) -> dict[str, float]:
-    """Fetch Chatbot Arena ELO scores via rows API."""
-    scores: dict[str, float] = {}
-    offset = 0
-
-    while True:
-        resp = client.get(
-            ARENA_ROWS_URL,
-            params={
-                "dataset": ARENA_DATASET,
-                "config": "default",
-                "split": "train",
-                "offset": str(offset),
-                "length": "100",
-            },
-        )
-        resp.raise_for_status()
-        data = resp.json()
-        rows = data.get("rows", [])
-        if not rows:
-            break
-
-        for r in rows:
-            row = r.get("row", {})
-            model_name = str(row.get("Model", ""))
-            elo = row.get("Arena Score", 0)
-            org = str(row.get("Organization", ""))
-            lic = str(row.get("License", ""))
-
-            if not model_name or not elo or elo <= 0:
-                continue
-            # Skip proprietary models (can't run locally)
-            if "Proprietary" in lic or "Propretary" in lic:
-                continue
-
-            normalized = _normalize_arena_elo(elo)
-            # Map to all potential HF IDs
-            hf_ids = _arena_name_to_hf_ids(model_name, org)
-            for hf_id in hf_ids:
-                scores[hf_id] = normalized
-
-        offset += len(rows)
-        total = data.get("num_rows_total", 0)
-        if total and offset >= total:
-            break
-
-    return scores
-
-
-def _fetch_leaderboard_parquet(client: httpx.Client) -> dict[str, float]:
-    """Download Open LLM Leaderboard parquet (requires pyarrow)."""
-    import pyarrow.parquet as pq
-
-    resp = client.get(LEADERBOARD_PARQUET_URL, follow_redirects=True)
-    resp.raise_for_status()
-    table = pq.read_table(
-        io.BytesIO(resp.content),
-        columns=["fullname", "Average ⬆️"],
-    )
-    d = table.to_pydict()
-    scores: dict[str, float] = {}
-    for i in range(len(d["fullname"])):
-        name = d["fullname"][i]
-        avg = d["Average ⬆️"][i]
-        if name and avg and avg > 0:
-            scores[name] = _normalize_leaderboard_avg(avg)
-    return scores
-
-
-def _fetch_leaderboard_api(client: httpx.Client) -> dict[str, float]:
-    """Fetch Open LLM Leaderboard via rows API (no pyarrow needed)."""
-    scores: dict[str, float] = {}
-    offset = 0
-
-    while True:
-        resp = client.get(
-            LEADERBOARD_ROWS_URL,
-            params={
-                "dataset": LEADERBOARD_DATASET,
-                "config": "default",
-                "split": "train",
-                "offset": str(offset),
-                "length": "100",
-            },
-        )
-        resp.raise_for_status()
-        data = resp.json()
-        rows = data.get("rows", [])
-        if not rows:
-            break
-
-        for r in rows:
-            row = r.get("row", {})
-            name = row.get("fullname")
-            avg = row.get("Average ⬆️")
-            if name and avg and avg > 0:
-                scores[name] = _normalize_leaderboard_avg(avg)
-
-        offset += len(rows)
-        total = data.get("num_rows_total", 0)
-        if total and offset >= total:
-            break
-
-    return scores
 
 
 _LINEAGE_DEMOTION_REGEX = None
@@ -337,7 +129,7 @@ def _apply_lineage_recency_demotion(
     return out
 
 
-def fetch_benchmark_scores() -> dict[str, float]:
+async def fetch_benchmark_scores() -> dict[str, float]:
     """Fetch and combine benchmark scores from multiple sources.
 
     Sources, merged in this order (later overwrites earlier on conflict):
@@ -348,15 +140,46 @@ def fetch_benchmark_scores() -> dict[str, float]:
       5. Artificial Analysis Intelligence Index (covers DeepSeek V4, GLM-5,
          Kimi K2.6, MiMo V2.5, Qwen3.6 — fills the Arena/Leaderboard gap)
 
-    Returns dict mapping model_id -> normalized score (0-100). Any source
-    that fails is logged and skipped; the function never raises.
+    Returns dict mapping model_id -> normalized score (0-100). All sources
+    are fetched concurrently; any source that fails is logged and skipped,
+    and the function never raises.
     """
     from whichllm.models.benchmark_sources import (
         fetch_aa_index_scores,
         fetch_aider_polyglot_scores,
+        fetch_arena_scores,
+        fetch_leaderboard_with_fallback,
         fetch_livebench_scores,
         fetch_vision_scores,
+        get_aa_curated_fallback,
+        get_livebench_curated_fallback,
     )
+
+    async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+        client.headers["User-Agent"] = f"whichllm/{_current_version()}"
+        leaderboard_task = asyncio.create_task(fetch_leaderboard_with_fallback(client))
+        arena_task = asyncio.create_task(fetch_arena_scores(client))
+        livebench_task = asyncio.create_task(fetch_livebench_scores(client))
+        aa_task = asyncio.create_task(fetch_aa_index_scores(client))
+        aider_task = asyncio.create_task(fetch_aider_polyglot_scores(client))
+        vision_task = asyncio.create_task(fetch_vision_scores(client))
+
+        (
+            lb_result,
+            arena_result,
+            livebench_result,
+            aa_result,
+            aider_result,
+            vision_result,
+        ) = await asyncio.gather(
+            leaderboard_task,
+            arena_task,
+            livebench_task,
+            aa_task,
+            aider_task,
+            vision_task,
+            return_exceptions=True,
+        )
 
     # Layered merge: build a "current" dict from live sources (AA, LiveBench,
     # Aider) and a "frozen" dict from archived sources (OLLB v2, Arena). The
@@ -367,73 +190,65 @@ def fetch_benchmark_scores() -> dict[str, float]:
     frozen: dict[str, float] = {}
     current: dict[str, float] = {}
 
-    with httpx.Client(timeout=30.0) as client:
-        # Frozen tier #1: Open LLM Leaderboard v2 (archived 2025-06)
-        try:
-            try:
-                lb_scores = _fetch_leaderboard_parquet(client)
-            except ImportError:
-                lb_scores = _fetch_leaderboard_api(client)
-            frozen.update(lb_scores)
-            logger.debug(f"Leaderboard: {len(lb_scores)} scores (frozen)")
-        except Exception as e:
-            logger.warning(f"Leaderboard fetch failed: {e}")
+    # Frozen tier #1: Open LLM Leaderboard v2 (archived 2025-06)
+    if isinstance(lb_result, BaseException):
+        logger.warning(f"Leaderboard fetch failed: {lb_result}")
+    else:
+        frozen.update(lb_result)
+        logger.debug(f"Leaderboard: {len(lb_result)} scores (frozen)")
 
-        # Frozen tier #2: Chatbot Arena ELO (frozen 2025-07-17)
-        try:
-            arena_scores = _fetch_arena_scores(client)
-            for k, v in arena_scores.items():
-                if frozen.get(k, 0.0) < v:
-                    frozen[k] = v
-            logger.debug(f"Arena: {len(arena_scores)} scores (frozen)")
-        except Exception as e:
-            logger.warning(f"Arena fetch failed: {e}")
+    # Frozen tier #2: Chatbot Arena ELO (frozen 2025-07-17)
+    if isinstance(arena_result, BaseException):
+        logger.warning(f"Arena fetch failed, using fallback: {arena_result}")
+    else:
+        for k, v in arena_result.items():
+            if frozen.get(k, 0.0) < v:
+                frozen[k] = v
+        logger.debug(f"Arena: {len(arena_result)} scores (frozen)")
 
-        # Current tier: LiveBench (monthly-refreshed)
-        try:
-            lb_scores = fetch_livebench_scores(client)
-            for k, v in lb_scores.items():
-                if current.get(k, 0.0) < v:
-                    current[k] = v
-            logger.debug(f"LiveBench: {len(lb_scores)} scores (current)")
-        except Exception as e:
-            logger.debug(f"LiveBench fetch failed: {e}")
+    # Current tier: LiveBench (monthly-refreshed)
+    if isinstance(livebench_result, BaseException):
+        logger.warning(f"LiveBench fetch failed, will use fallback: {livebench_result}")
+        livebench_result = get_livebench_curated_fallback()
 
-        # Current tier: Artificial Analysis Intelligence Index (~weekly refresh)
-        try:
-            aa_scores = fetch_aa_index_scores(client)
-            for k, v in aa_scores.items():
-                if current.get(k, 0.0) < v:
-                    current[k] = v
-            logger.debug(f"AA Index: {len(aa_scores)} scores (current)")
-        except Exception as e:
-            logger.debug(f"AA Index fetch failed: {e}")
+    for k, v in livebench_result.items():
+        if current.get(k, 0.0) < v:
+            current[k] = v
+    logger.debug(f"LiveBench: {len(livebench_result)} scores (current)")
 
-        # Current tier: Aider polyglot (coding-specific). Treat as a current
-        # source but soft-merged — coding is one axis of capability, so a high
-        # Aider score is informative but shouldn't unilaterally dethrone a
-        # weaker-coding-but-strong-general AA result.
-        try:
-            aider_scores = fetch_aider_polyglot_scores(client)
-            for k, v in aider_scores.items():
-                if current.get(k, 0.0) < v * 0.85:
-                    current[k] = v * 0.85
-            logger.debug(f"Aider polyglot: {len(aider_scores)} scores (current, 0.85x)")
-        except Exception as e:
-            logger.debug(f"Aider fetch failed: {e}")
+    # Current tier: Artificial Analysis Intelligence Index (~weekly refresh)
+    if isinstance(aa_result, BaseException):
+        logger.warning(f"AA Index fetch failed, will use fallback: {aa_result}")
+        aa_result = get_aa_curated_fallback()
 
-        # Current tier: vision-language capability index. Text leaderboards
-        # don't score VLMs, so without this the only VLM with a direct hit
-        # was a two-generations-old Qwen2-VL-7B. Profile filtering ensures
-        # these scores only affect ``--profile vision`` rankings.
-        try:
-            vision_scores = fetch_vision_scores(client)
-            for k, v in vision_scores.items():
-                if current.get(k, 0.0) < v:
-                    current[k] = v
-            logger.debug(f"Vision: {len(vision_scores)} scores (current)")
-        except Exception as e:
-            logger.debug(f"Vision fetch failed: {e}")
+    for k, v in aa_result.items():
+        if current.get(k, 0.0) < v:
+            current[k] = v
+    logger.debug(f"AA Index: {len(aa_result)} scores (current)")
+
+    # Current tier: Aider polyglot (coding-specific). Treat as a current
+    # source but soft-merged — coding is one axis of capability, so a high
+    # Aider score is informative but shouldn't unilaterally dethrone a
+    # weaker-coding-but-strong-general AA result.
+    if isinstance(aider_result, BaseException):
+        logger.warning(f"Aider fetch failed: {aider_result}")
+    else:
+        for k, v in aider_result.items():
+            if current.get(k, 0.0) < v * 0.85:
+                current[k] = v * 0.85
+        logger.debug(f"Aider polyglot: {len(aider_result)} scores (current, 0.85x)")
+
+    # Current tier: vision-language capability index. Text leaderboards
+    # don't score VLMs, so without this the only VLM with a direct hit
+    # was a two-generations-old Qwen2-VL-7B. Profile filtering ensures
+    # these scores only affect ``--profile vision`` rankings.
+    if isinstance(vision_result, BaseException):
+        logger.warning(f"Vision fetch failed: {vision_result}")
+    else:
+        for k, v in vision_result.items():
+            if current.get(k, 0.0) < v:
+                current[k] = v
+        logger.debug(f"Vision: {len(vision_result)} scores (current)")
 
     # Build combined: current overrides frozen entry-by-entry, but frozen still
     # contributes for any id no current source has tracked.

--- a/src/whichllm/models/benchmark_sources/__init__.py
+++ b/src/whichllm/models/benchmark_sources/__init__.py
@@ -9,9 +9,19 @@ returns malformed data, they log a warning and return an empty dict so the
 main benchmark merge pipeline does not abort.
 """
 
-from whichllm.models.benchmark_sources.aa_index import fetch_aa_index_scores
+from whichllm.models.benchmark_sources.aa_index import (
+    fetch_aa_index_scores,
+    get_aa_curated_fallback,
+)
 from whichllm.models.benchmark_sources.aider import fetch_aider_polyglot_scores
-from whichllm.models.benchmark_sources.livebench import fetch_livebench_scores
+from whichllm.models.benchmark_sources.chatbot_arena import fetch_arena_scores
+from whichllm.models.benchmark_sources.livebench import (
+    fetch_livebench_scores,
+    get_livebench_curated_fallback,
+)
+from whichllm.models.benchmark_sources.open_llm_leaderboard import (
+    fetch_leaderboard_with_fallback,
+)
 from whichllm.models.benchmark_sources.vision import fetch_vision_scores
 
 # Newest curated-fallback date across all sources. Live scrapes are merged
@@ -26,6 +36,10 @@ __all__ = [
     "BENCHMARK_SNAPSHOT",
     "fetch_aa_index_scores",
     "fetch_aider_polyglot_scores",
+    "fetch_arena_scores",
+    "fetch_leaderboard_with_fallback",
     "fetch_livebench_scores",
     "fetch_vision_scores",
+    "get_aa_curated_fallback",
+    "get_livebench_curated_fallback",
 ]

--- a/src/whichllm/models/benchmark_sources/aa_index.py
+++ b/src/whichllm/models/benchmark_sources/aa_index.py
@@ -15,9 +15,12 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 
 import httpx
+
+from whichllm.models.benchmark_sources.constants import _NEXT_DATA_RE
+from whichllm.models.benchmark_sources.types import ExtractionFailed
+from whichllm.models.benchmark_sources.utils import _walk
 
 logger = logging.getLogger(__name__)
 
@@ -189,24 +192,6 @@ def _normalize_aa_index(index: float) -> float:
     return max(0.0, min(100.0, round(normalized, 1)))
 
 
-_NEXT_DATA_RE = re.compile(
-    r'<script id="__NEXT_DATA__"[^>]*>(?P<json>.*?)</script>', re.DOTALL
-)
-
-
-def _walk(obj, depth: int = 0):
-    """Yield every dict encountered while recursively walking a JSON tree."""
-    if depth > 12:
-        return
-    if isinstance(obj, dict):
-        yield obj
-        for v in obj.values():
-            yield from _walk(v, depth + 1)
-    elif isinstance(obj, list):
-        for item in obj:
-            yield from _walk(item, depth + 1)
-
-
 def _extract_aa_pairs(payload: dict) -> list[tuple[str, float]]:
     """Walk the Next.js payload looking for {name, intelligenceIndex}-shaped
     objects regardless of where they are nested."""
@@ -236,77 +221,50 @@ def _extract_aa_pairs(payload: dict) -> list[tuple[str, float]]:
     return pairs
 
 
-def fetch_aa_index_scores(
-    client: httpx.Client | None = None, timeout: float = 20.0
-) -> dict[str, float]:
+async def fetch_aa_index_scores(client: httpx.AsyncClient) -> dict[str, float]:
     """Fetch Artificial Analysis Intelligence Index scores.
 
     Returns ``{hf_id: normalized_score_0_100}`` for every model AA reports
     that we can map back to a HuggingFace repo via :data:`AA_NAME_TO_HF_IDS`.
 
-    On any error returns ``{}``.
+    Raises on HTTP / parse failure.
     """
     scores: dict[str, float] = {}
-    own_client = False
-    if client is None:
-        client = httpx.Client(timeout=timeout, follow_redirects=True)
-        own_client = True
-    try:
-        resp = client.get(
-            AA_LEADERBOARD_URL,
-            headers={"User-Agent": "whichllm/0.5 (+https://github.com/local)"},
-        )
-        resp.raise_for_status()
-        text = resp.text
-        match = _NEXT_DATA_RE.search(text)
-        if not match:
-            logger.debug("AA leaderboard: __NEXT_DATA__ payload not found")
-            return _curated_fallback()
-        try:
-            payload = json.loads(match.group("json"))
-        except json.JSONDecodeError as e:
-            logger.debug(f"AA leaderboard: malformed JSON payload: {e}")
-            return _curated_fallback()
-        pairs = _extract_aa_pairs(payload)
-        if not pairs:
-            logger.debug("AA leaderboard: no (name, score) pairs found, using fallback")
-            return _curated_fallback()
-        # When the same display name appears multiple times (different size
-        # tiers), keep the maximum value — it represents the most capable
-        # variant available.
-        best_by_name: dict[str, float] = {}
-        for name, score in pairs:
-            current = best_by_name.get(name)
-            if current is None or score > current:
-                best_by_name[name] = score
-        for name, score in best_by_name.items():
-            hf_ids = AA_NAME_TO_HF_IDS.get(name)
-            if not hf_ids:
-                continue
-            normalized = _normalize_aa_index(score)
-            if normalized <= 0:
-                continue
-            for hf_id in hf_ids:
-                # Use max so a higher-confidence source wins on conflict.
-                existing = scores.get(hf_id, 0.0)
-                if normalized > existing:
-                    scores[hf_id] = normalized
-        if not scores:
-            logger.debug(
-                "AA index: live fetch returned 0 mapped scores, using fallback"
-            )
-            return _curated_fallback()
-        logger.debug(f"AA index: {len(scores)} mapped scores")
-        return scores
-    except (httpx.HTTPError, ValueError) as e:
-        logger.debug(f"AA leaderboard fetch failed: {e}, using fallback")
-        return _curated_fallback()
-    finally:
-        if own_client:
-            client.close()
+    resp = await client.get(AA_LEADERBOARD_URL)
+    resp.raise_for_status()
+    match = _NEXT_DATA_RE.search(resp.text)
+    if not match:
+        raise ExtractionFailed("__NEXT_DATA__ payload not found")
+    payload = json.loads(match.group("json"))
+    pairs = _extract_aa_pairs(payload)
+    if not pairs:
+        raise ExtractionFailed("AA leaderboard: no (name, score) pairs found")
+    # When the same display name appears multiple times (different size
+    # tiers), keep the maximum value — it represents the most capable
+    # variant available.
+    best_by_name: dict[str, float] = {}
+    for name, score in pairs:
+        current = best_by_name.get(name)
+        if current is None or score > current:
+            best_by_name[name] = score
+    for name, score in best_by_name.items():
+        hf_ids = AA_NAME_TO_HF_IDS.get(name)
+        if not hf_ids:
+            continue
+        normalized = _normalize_aa_index(score)
+        if normalized <= 0:
+            continue
+        for hf_id in hf_ids:
+            existing = scores.get(hf_id, 0.0)
+            if normalized > existing:
+                scores[hf_id] = normalized
+    if not scores:
+        raise ExtractionFailed("AA index: live fetch returned 0 mapped scores")
+    logger.debug(f"AA index: {len(scores)} mapped scores")
+    return scores
 
 
-def _curated_fallback() -> dict[str, float]:
+def get_aa_curated_fallback() -> dict[str, float]:
     """Return the 2026-05-14 curated snapshot, normalized to the 0-100 scale.
 
     Used whenever the live HTML scrape cannot extract data — for example

--- a/src/whichllm/models/benchmark_sources/aider.py
+++ b/src/whichllm/models/benchmark_sources/aider.py
@@ -105,45 +105,29 @@ def _parse_yaml_lite(text: str) -> list[tuple[str, float]]:
     return out
 
 
-def fetch_aider_polyglot_scores(
-    client: httpx.Client | None = None, timeout: float = 20.0
-) -> dict[str, float]:
-    """Fetch Aider polyglot pass-rates; empty dict on any failure."""
+async def fetch_aider_polyglot_scores(client: httpx.AsyncClient) -> dict[str, float]:
+    """Fetch Aider polyglot pass-rates. Raises on HTTP / parse failure."""
     scores: dict[str, float] = {}
-    own_client = False
-    if client is None:
-        client = httpx.Client(timeout=timeout, follow_redirects=True)
-        own_client = True
-    try:
-        resp = client.get(
-            AIDER_POLYGLOT_YML_URL,
-            headers={"User-Agent": "whichllm/0.5"},
-        )
-        resp.raise_for_status()
-        pairs = _parse_yaml_lite(resp.text)
-        if not pairs:
-            logger.debug("Aider polyglot: 0 records parsed")
-            return {}
-        best_by_name: dict[str, float] = {}
-        for name, rate in pairs:
-            cur = best_by_name.get(name)
-            if cur is None or rate > cur:
-                best_by_name[name] = rate
-        for name, rate in best_by_name.items():
-            ids = AIDER_NAME_TO_HF_IDS.get(name)
-            if not ids:
-                continue
-            normalized = _normalize(rate)
-            if normalized <= 0:
-                continue
-            for hf_id in ids:
-                if scores.get(hf_id, 0.0) < normalized:
-                    scores[hf_id] = normalized
-        logger.debug(f"Aider polyglot: {len(scores)} mapped scores")
-        return scores
-    except (httpx.HTTPError, ValueError) as e:
-        logger.debug(f"Aider polyglot fetch failed: {e}")
+    resp = await client.get(AIDER_POLYGLOT_YML_URL)
+    resp.raise_for_status()
+    pairs = _parse_yaml_lite(resp.text)
+    if not pairs:
+        logger.debug("Aider polyglot: 0 records parsed")
         return {}
-    finally:
-        if own_client:
-            client.close()
+    best_by_name: dict[str, float] = {}
+    for name, rate in pairs:
+        cur = best_by_name.get(name)
+        if cur is None or rate > cur:
+            best_by_name[name] = rate
+    for name, rate in best_by_name.items():
+        ids = AIDER_NAME_TO_HF_IDS.get(name)
+        if not ids:
+            continue
+        normalized = _normalize(rate)
+        if normalized <= 0:
+            continue
+        for hf_id in ids:
+            if scores.get(hf_id, 0.0) < normalized:
+                scores[hf_id] = normalized
+    logger.debug(f"Aider polyglot: {len(scores)} mapped scores")
+    return scores

--- a/src/whichllm/models/benchmark_sources/chatbot_arena.py
+++ b/src/whichllm/models/benchmark_sources/chatbot_arena.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import re
+
+import httpx
+
+# --- Data source URLs ---
+ARENA_ROWS_URL = "https://datasets-server.huggingface.co/rows"
+ARENA_DATASET = "mathewhe/chatbot-arena-elo"
+
+# --- Arena ELO normalization ---
+# Open-source ELO range: ~1030 (worst) to ~1424 (best). Arena is frozen
+# 2025-07-17 (no new models added) so the leaderboard cannot reflect any
+# 2025-Q3+ release; we cap the normalized output at 82 so newer benchmark
+# sources (AA Index / LiveBench, which can reach 95+) decisively win on
+# conflict.
+_ARENA_ELO_MIN = 1030
+_ARENA_ELO_MAX = 1430
+_ARENA_MAX_NORMALIZED = 82.0
+
+# --- Arena display name -> HuggingFace org mapping ---
+_ARENA_ORG_TO_HF: dict[str, list[str]] = {
+    "Alibaba": ["Qwen"],
+    "Meta": ["meta-llama"],
+    "DeepSeek": ["deepseek-ai"],
+    "DeepSeek AI": ["deepseek-ai"],
+    "Google": ["google"],
+    "Mistral": ["mistralai"],
+    "Microsoft": ["microsoft"],
+    "Nvidia": ["nvidia"],
+    "01 AI": ["01-ai"],
+    "Allen AI": ["allenai"],
+    "Ai2": ["allenai"],
+    "AllenAI/UW": ["allenai"],
+    "Cohere": ["CohereForAI"],
+    "HuggingFace": ["HuggingFaceH4", "huggingface"],
+    "AI21 Labs": ["ai21labs"],
+    "NousResearch": ["NousResearch"],
+    "NexusFlow": ["Nexusflow"],
+    "Princeton": ["princeton-nlp"],
+    "IBM": ["ibm-granite"],
+    "InternLM": ["internlm"],
+    "Together AI": ["togethercomputer"],
+    "TII": ["tiiuae"],
+    "MiniMax": ["MiniMaxAI"],
+    "MosaicML": ["mosaicml"],
+    "Databricks": ["databricks"],
+    "Moonshot": ["moonshotai"],
+    "UC Berkeley": ["berkeley-nest"],
+    "Cognitive Computations": ["cognitivecomputations"],
+    "Upstage AI": ["upstage"],
+    "UW": ["timdettmers"],
+    "Snowflake": ["Snowflake"],
+    "LMSYS": ["lmsys"],
+    "OpenChat": ["openchat"],
+}
+
+
+def _normalize_arena_elo(elo: float) -> float:
+    """Normalize Arena ELO to a frozen-source-aware 0-_ARENA_MAX_NORMALIZED scale."""
+    score = (
+        (elo - _ARENA_ELO_MIN)
+        / (_ARENA_ELO_MAX - _ARENA_ELO_MIN)
+        * _ARENA_MAX_NORMALIZED
+    )
+    return max(0.0, min(_ARENA_MAX_NORMALIZED, round(score, 1)))
+
+
+def _arena_name_to_hf_ids(model_name: str, org: str) -> list[str]:
+    """Convert Arena display name to potential HuggingFace model IDs."""
+    hf_orgs = _ARENA_ORG_TO_HF.get(org, [])
+    candidates = []
+
+    # Clean the model name: remove date suffixes like "(03-2025)"
+    clean_name = re.sub(r"\s*\([\d-]+\)\s*$", "", model_name).strip()
+    # Remove -bf16, -fp8 suffixes for base matching
+    base_name = re.sub(r"-(bf16|fp8|fp16)$", "", clean_name, flags=re.IGNORECASE)
+
+    for hf_org in hf_orgs:
+        candidates.append(f"{hf_org}/{clean_name}")
+        if base_name != clean_name:
+            candidates.append(f"{hf_org}/{base_name}")
+        # Try with -Instruct suffix stripped for base model matching
+        no_instruct = re.sub(r"-Instruct$", "", clean_name)
+        if no_instruct != clean_name:
+            candidates.append(f"{hf_org}/{no_instruct}")
+
+    return candidates
+
+
+async def fetch_arena_scores(client: httpx.AsyncClient) -> dict[str, float]:
+    """Fetch Chatbot Arena ELO scores via rows API."""
+    scores: dict[str, float] = {}
+    offset = 0
+
+    while True:
+        resp = await client.get(
+            ARENA_ROWS_URL,
+            params={
+                "dataset": ARENA_DATASET,
+                "config": "default",
+                "split": "train",
+                "offset": str(offset),
+                "length": "100",
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        rows = data.get("rows", [])
+        if not rows:
+            break
+
+        for r in rows:
+            row = r.get("row", {})
+            model_name = str(row.get("Model", ""))
+            elo = row.get("Arena Score", 0)
+            org = str(row.get("Organization", ""))
+            lic = str(row.get("License", ""))
+
+            if not model_name or not elo or elo <= 0:
+                continue
+            # Skip proprietary models (can't run locally)
+            if "Proprietary" in lic or "Propretary" in lic:
+                continue
+
+            normalized = _normalize_arena_elo(elo)
+            # Map to all potential HF IDs
+            hf_ids = _arena_name_to_hf_ids(model_name, org)
+            for hf_id in hf_ids:
+                scores[hf_id] = normalized
+
+        offset += len(rows)
+        total = data.get("num_rows_total", 0)
+        if total and offset >= total:
+            break
+
+    return scores

--- a/src/whichllm/models/benchmark_sources/constants.py
+++ b/src/whichllm/models/benchmark_sources/constants.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+import re
+
+_NEXT_DATA_RE = re.compile(
+    r'<script id="__NEXT_DATA__"[^>]*>(?P<json>.*?)</script>', re.DOTALL
+)

--- a/src/whichllm/models/benchmark_sources/livebench.py
+++ b/src/whichllm/models/benchmark_sources/livebench.py
@@ -13,9 +13,12 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 
 import httpx
+
+from whichllm.models.benchmark_sources.constants import _NEXT_DATA_RE
+from whichllm.models.benchmark_sources.types import ExtractionFailed
+from whichllm.models.benchmark_sources.utils import _walk
 
 logger = logging.getLogger(__name__)
 
@@ -110,23 +113,6 @@ LIVEBENCH_NAME_TO_HF_IDS: dict[str, list[str]] = {
 }
 
 
-_NEXT_DATA_RE = re.compile(
-    r'<script id="__NEXT_DATA__"[^>]*>(?P<json>.*?)</script>', re.DOTALL
-)
-
-
-def _walk(obj, depth: int = 0):
-    if depth > 12:
-        return
-    if isinstance(obj, dict):
-        yield obj
-        for v in obj.values():
-            yield from _walk(v, depth + 1)
-    elif isinstance(obj, list):
-        for item in obj:
-            yield from _walk(item, depth + 1)
-
-
 def _extract_lb_pairs(payload: dict) -> list[tuple[str, float]]:
     pairs: list[tuple[str, float]] = []
     for node in _walk(payload):
@@ -168,65 +154,40 @@ def _normalize_livebench(score: float) -> float:
     return max(0.0, min(100.0, round(normalized, 1)))
 
 
-def fetch_livebench_scores(
-    client: httpx.Client | None = None, timeout: float = 20.0
-) -> dict[str, float]:
-    """Fetch LiveBench scores; empty dict on any failure."""
+async def fetch_livebench_scores(client: httpx.AsyncClient) -> dict[str, float]:
+    """Fetch LiveBench scores. Raises on HTTP / parse failure."""
     scores: dict[str, float] = {}
-    own_client = False
-    if client is None:
-        client = httpx.Client(timeout=timeout, follow_redirects=True)
-        own_client = True
-    try:
-        resp = client.get(
-            LIVEBENCH_URL,
-            headers={"User-Agent": "whichllm/0.5"},
-        )
-        resp.raise_for_status()
-        match = _NEXT_DATA_RE.search(resp.text)
-        if not match:
-            logger.debug("LiveBench: __NEXT_DATA__ payload not found, using fallback")
-            return _curated_fallback()
-        try:
-            payload = json.loads(match.group("json"))
-        except json.JSONDecodeError as e:
-            logger.debug(f"LiveBench: malformed payload: {e}, using fallback")
-            return _curated_fallback()
-        pairs = _extract_lb_pairs(payload)
-        if not pairs:
-            logger.debug("LiveBench: no (name, score) pairs extracted, using fallback")
-            return _curated_fallback()
-        best_by_name: dict[str, float] = {}
-        for name, score in pairs:
-            cur = best_by_name.get(name)
-            if cur is None or score > cur:
-                best_by_name[name] = score
-        for name, score in best_by_name.items():
-            ids = LIVEBENCH_NAME_TO_HF_IDS.get(name)
-            if not ids:
-                continue
-            normalized = _normalize_livebench(score)
-            if normalized <= 0:
-                continue
-            for hf_id in ids:
-                if scores.get(hf_id, 0.0) < normalized:
-                    scores[hf_id] = normalized
-        if not scores:
-            logger.debug(
-                "LiveBench: live fetch returned 0 mapped scores, using fallback"
-            )
-            return _curated_fallback()
-        logger.debug(f"LiveBench: {len(scores)} mapped scores")
-        return scores
-    except (httpx.HTTPError, ValueError) as e:
-        logger.debug(f"LiveBench fetch failed: {e}, using fallback")
-        return _curated_fallback()
-    finally:
-        if own_client:
-            client.close()
+    resp = await client.get(LIVEBENCH_URL)
+    resp.raise_for_status()
+    match = _NEXT_DATA_RE.search(resp.text)
+    if not match:
+        raise ExtractionFailed("__NEXT_DATA__ payload not found")
+    payload = json.loads(match.group("json"))
+    pairs = _extract_lb_pairs(payload)
+    if not pairs:
+        raise ExtractionFailed("no (name, score) pairs extracted, using fallback")
+    best_by_name: dict[str, float] = {}
+    for name, score in pairs:
+        cur = best_by_name.get(name)
+        if cur is None or score > cur:
+            best_by_name[name] = score
+    for name, score in best_by_name.items():
+        ids = LIVEBENCH_NAME_TO_HF_IDS.get(name)
+        if not ids:
+            continue
+        normalized = _normalize_livebench(score)
+        if normalized <= 0:
+            continue
+        for hf_id in ids:
+            if scores.get(hf_id, 0.0) < normalized:
+                scores[hf_id] = normalized
+    if not scores:
+        raise ExtractionFailed("live fetch returned 0 mapped scores")
+    logger.debug(f"LiveBench: {len(scores)} mapped scores")
+    return scores
 
 
-def _curated_fallback() -> dict[str, float]:
+def get_livebench_curated_fallback() -> dict[str, float]:
     """Return the 2026-04 curated snapshot, normalized to the 0-100 scale.
 
     Used when the live HTML scrape cannot extract data. This is the same

--- a/src/whichllm/models/benchmark_sources/open_llm_leaderboard.py
+++ b/src/whichllm/models/benchmark_sources/open_llm_leaderboard.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import io
+
+import httpx
+
+LEADERBOARD_PARQUET_URL = (
+    "https://huggingface.co/api/datasets/open-llm-leaderboard/contents"
+    "/parquet/default/train/0.parquet"
+)
+LEADERBOARD_ROWS_URL = "https://datasets-server.huggingface.co/rows"
+LEADERBOARD_DATASET = "open-llm-leaderboard/contents"
+
+# --- Leaderboard normalization ---
+# OLLB v2 averages range ~5 to ~52. The leaderboard is archived 2025-06 with
+# the top slot held by Qwen2.5-32B (47.6 raw = 91.5 if uncapped); capping at
+# 78 prevents an older generation with a strong-but-frozen OLLB score from
+# dominating rankings that now have AA Index / LiveBench coverage too.
+_LB_AVG_MAX = 52
+_OLLB_MAX_NORMALIZED = 78.0
+
+
+async def _fetch_leaderboard_parquet(client: httpx.AsyncClient) -> dict[str, float]:
+    """Download Open LLM Leaderboard parquet (requires pyarrow)."""
+    import pyarrow.parquet as pq
+
+    resp = await client.get(LEADERBOARD_PARQUET_URL, follow_redirects=True)
+    resp.raise_for_status()
+    table = pq.read_table(
+        io.BytesIO(resp.content),
+        columns=["fullname", "Average ⬆️"],
+    )
+    d = table.to_pydict()
+    scores: dict[str, float] = {}
+    for i in range(len(d["fullname"])):
+        name = d["fullname"][i]
+        avg = d["Average ⬆️"][i]
+        if name and avg and avg > 0:
+            scores[name] = _normalize_leaderboard_avg(avg)
+    return scores
+
+
+async def _fetch_leaderboard_api(client: httpx.AsyncClient) -> dict[str, float]:
+    """Fetch Open LLM Leaderboard via rows API (no pyarrow needed)."""
+    scores: dict[str, float] = {}
+    offset = 0
+
+    while True:
+        resp = await client.get(
+            LEADERBOARD_ROWS_URL,
+            params={
+                "dataset": LEADERBOARD_DATASET,
+                "config": "default",
+                "split": "train",
+                "offset": str(offset),
+                "length": "100",
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        rows = data.get("rows", [])
+        if not rows:
+            break
+
+        for r in rows:
+            row = r.get("row", {})
+            name = row.get("fullname")
+            avg = row.get("Average ⬆️")
+            if name and avg and avg > 0:
+                scores[name] = _normalize_leaderboard_avg(avg)
+
+        offset += len(rows)
+        total = data.get("num_rows_total", 0)
+        if total and offset >= total:
+            break
+
+    return scores
+
+
+def _normalize_leaderboard_avg(avg: float) -> float:
+    """Normalize Open LLM Leaderboard average to 0-_OLLB_MAX_NORMALIZED scale."""
+    score = avg / _LB_AVG_MAX * _OLLB_MAX_NORMALIZED
+    return max(0.0, min(_OLLB_MAX_NORMALIZED, round(score, 1)))
+
+
+async def fetch_leaderboard_with_fallback(
+    client: httpx.AsyncClient,
+) -> dict[str, float]:
+    """Prefer the parquet path (one request, full table) and fall back to the
+    paginated rows API when pyarrow is unavailable."""
+    try:
+        return await _fetch_leaderboard_parquet(client)
+    except ImportError:
+        return await _fetch_leaderboard_api(client)

--- a/src/whichllm/models/benchmark_sources/types.py
+++ b/src/whichllm/models/benchmark_sources/types.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+class ExtractionFailed(Exception):
+    pass

--- a/src/whichllm/models/benchmark_sources/utils.py
+++ b/src/whichllm/models/benchmark_sources/utils.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+
+def _walk(obj, depth: int = 0):
+    """Yield every dict encountered while recursively walking a JSON tree."""
+    if depth > 12:
+        return
+    if isinstance(obj, dict):
+        yield obj
+        for v in obj.values():
+            yield from _walk(v, depth + 1)
+    elif isinstance(obj, list):
+        for item in obj:
+            yield from _walk(item, depth + 1)

--- a/src/whichllm/models/benchmark_sources/vision.py
+++ b/src/whichllm/models/benchmark_sources/vision.py
@@ -72,14 +72,12 @@ VISION_FALLBACK_2026_05: dict[str, float] = {
 }
 
 
-def fetch_vision_scores(
-    client: httpx.Client | None = None, timeout: float = 20.0
-) -> dict[str, float]:
+async def fetch_vision_scores(client: httpx.AsyncClient) -> dict[str, float]:
     """Return curated VLM capability scores.
 
     No stable live source exists, so this returns the frozen snapshot.
-    The ``client``/``timeout`` parameters mirror the other source
-    functions so the caller can treat all sources uniformly and a live
-    scrape can be slotted in later without changing call sites.
+    The ``client`` parameter mirrors the other source functions so the
+    caller can treat all sources uniformly and a live scrape can be
+    slotted in later without changing call sites.
     """
     return dict(VISION_FALLBACK_2026_05)

--- a/src/whichllm/utils.py
+++ b/src/whichllm/utils.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from importlib.metadata import version, PackageNotFoundError
+
+
+def _current_version() -> str:
+    """Return installed package version."""
+    try:
+        return version("whichllm")
+    except PackageNotFoundError:
+        return "unknown"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,6 @@ from click.exceptions import Exit
 import whichllm.cli as cli_mod
 from whichllm.cli import (
     _auto_min_params_for_profile,
-    _current_version,
     _fill_missing_published_at,
     _generate_chat_script,
     _include_vision_candidates,
@@ -18,6 +17,7 @@ from whichllm.cli import (
     _validate_evidence,
     app,
 )
+from whichllm.utils import _current_version
 from whichllm.engine.types import CompatibilityResult
 from whichllm.hardware.types import GPUInfo, HardwareInfo
 from whichllm.models.types import GGUFVariant, ModelInfo


### PR DESCRIPTION
## What

* Convert benchmark fetchers to async
* Run benchmark fetchers in parallel
* Move all fetchers to their respective modules
* Move _current_version out of cli.py into whichllm/utils.py so it can be used for user-agent formation

## Why

Makes the "Fetching benchmarks" stage faster.

## Testing

- [x] Tests pass (`pytest`)
- [x] New tests added (if applicable)
  - Not added, just a refactor 
- [x] Tested on real hardware (if hardware-related)
  - Still works fine on my Mac