### PR TITLE
fix: provide transformers offload folder

### DIFF
--- a/src/whichllm/cli.py
+++ b/src/whichllm/cli.py
@@ -781,48 +781,64 @@ print("\\nBye!")
     device_map = '"cpu"' if cpu_only else '"auto"'
     dtype = "torch.float32" if cpu_only else '"auto"'
     return f'''\
+import shutil
+import tempfile
 import torch
 from threading import Thread
 from transformers import AutoModelForCausalLM, AutoTokenizer, TextIteratorStreamer
 
 model_id = "{model.id}"
-print(f"Loading {{model_id}}...")
-tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=True)
-model = AutoModelForCausalLM.from_pretrained(
-    model_id, device_map={device_map}, torch_dtype={dtype}, trust_remote_code=True,
-)
-print("Ready! Type 'exit' to quit.\\n")
-messages = []
-while True:
-    try:
-        user_input = input("> ")
-    except (KeyboardInterrupt, EOFError):
-        break
-    if user_input.strip().lower() in ("exit", "quit", "q"):
-        break
-    if not user_input.strip():
-        continue
-    messages.append({{"role": "user", "content": user_input}})
-    inputs = tokenizer.apply_chat_template(
-        messages,
-        return_tensors="pt",
-        return_dict=True,
-        add_generation_prompt=True,
-    ).to(model.device)
-    streamer = TextIteratorStreamer(tokenizer, skip_prompt=True, skip_special_tokens=True)
-    thread = Thread(
-        target=model.generate,
-        kwargs=dict(**inputs, max_new_tokens=512, streamer=streamer),
+offload_folder = tempfile.mkdtemp(prefix="whichllm_transformers_offload_")
+try:
+    print(f"Loading {{model_id}}...")
+    tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=True)
+    model = AutoModelForCausalLM.from_pretrained(
+        model_id,
+        device_map={device_map},
+        torch_dtype={dtype},
+        trust_remote_code=True,
+        offload_folder=offload_folder,
     )
-    thread.start()
-    full = ""
-    for text in streamer:
-        print(text, end="", flush=True)
-        full += text
-    thread.join()
-    print()
-    messages.append({{"role": "assistant", "content": full}})
-print("\\nBye!")
+    print("Ready! Type 'exit' to quit.\\n")
+    messages = []
+    while True:
+        try:
+            user_input = input("> ")
+        except (KeyboardInterrupt, EOFError):
+            break
+        if user_input.strip().lower() in ("exit", "quit", "q"):
+            break
+        if not user_input.strip():
+            continue
+        messages.append({{"role": "user", "content": user_input}})
+        inputs = tokenizer.apply_chat_template(
+            messages,
+            return_tensors="pt",
+            return_dict=True,
+            add_generation_prompt=True,
+        ).to(model.device)
+        streamer = TextIteratorStreamer(
+            tokenizer, skip_prompt=True, skip_special_tokens=True
+        )
+        thread = Thread(
+            target=model.generate,
+            kwargs=dict(**inputs, max_new_tokens=512, streamer=streamer),
+        )
+        thread.start()
+        full = ""
+        for text in streamer:
+            print(text, end="", flush=True)
+            full += text
+        thread.join()
+        print()
+        messages.append({{"role": "assistant", "content": full}})
+    print("\\nBye!")
+finally:
+    try:
+        del model
+    except NameError:
+        pass
+    shutil.rmtree(offload_folder, ignore_errors=True)
 '''
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -492,6 +492,18 @@ def test_transformers_chat_script_passes_tokenizer_mapping_to_generate():
     assert "kwargs=dict(input_ids=inputs" not in script
 
 
+def test_transformers_chat_script_provides_disk_offload_folder():
+    model = _make_model(model_id="org/Test-7B")
+
+    script = _generate_chat_script(
+        model, variant=None, context_length=4096, cpu_only=False
+    )
+
+    assert 'tempfile.mkdtemp(prefix="whichllm_transformers_offload_")' in script
+    assert "offload_folder=offload_folder" in script
+    assert "shutil.rmtree(offload_folder, ignore_errors=True)" in script
+
+
 def test_run_auto_pick_resolves_ranked_gguf_before_launch(monkeypatch):
     selected = ModelInfo(
         id="Qwen/Qwen3.6-27B",


### PR DESCRIPTION
## Summary

- Provide a temporary `offload_folder` for Transformers runs that use `device_map="auto"`.
- Clean up the temporary offload directory after the generated chat script exits or fails during load.
- Add a regression test for the generated Transformers script.

Fixes #5.

## Validation

- `ruff format --check src/whichllm/cli.py tests/test_cli.py`
- `uv run pytest -q -s tests/test_cli.py`
- generated script `ast.parse`
- `git diff --check`
- `uv run pytest -q -s` -> 186 passed
