### PR TITLE
fix: detect DGX Spark GB10 shared memory

### DIFF
--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -42,6 +42,10 @@ For known cards, `constants.py` provides:
 - memory bandwidth
 - compute capability
 
+DGX Spark / NVIDIA GB10 uses unified system memory. When the driver reports
+`memory.total` as unavailable, whichllm treats GB10 as shared memory and uses
+system RAM for fit checks.
+
 Compute capability is used to warn when a card is below the minimum expected by
 common local inference tools.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -186,6 +186,8 @@ discrete GPUs.
 
 The same is true for recognized AMD shared-memory APUs such as Strix Halo,
 Ryzen AI MAX, and Ryzen AI / Radeon 890M-class integrated graphics.
+DGX Spark / NVIDIA GB10 is handled the same way when NVIDIA reports GPU memory
+as unavailable.
 
 On Windows, `Win32_VideoController.AdapterRAM` can cap around 4 GB. whichllm
 uses the 64-bit registry memory value when it is available, and treats known

--- a/src/whichllm/constants.py
+++ b/src/whichllm/constants.py
@@ -66,6 +66,8 @@ GPU_BANDWIDTH: dict[str, float] = {
     # NVIDIA Data Center
     "H100": 3350.0,
     "H200": 4800.0,
+    "DGX Spark": 273.0,
+    "GB10": 273.0,
     "A100 80GB": 2039.0,
     "A100 40GB": 1555.0,
     "A100": 1555.0,
@@ -414,6 +416,8 @@ NVIDIA_COMPUTE_CAPABILITY: dict[str, tuple[int, int]] = {
     # Data Center
     "H100": (9, 0),
     "H200": (9, 0),
+    "DGX Spark": (12, 1),
+    "GB10": (12, 1),
     "A100": (8, 0),
     "A6000": (8, 6),
     "A5000": (8, 6),

--- a/src/whichllm/hardware/nvidia.py
+++ b/src/whichllm/hardware/nvidia.py
@@ -6,10 +6,12 @@ import logging
 import re
 import subprocess
 
-from whichllm.constants import GPU_BANDWIDTH, NVIDIA_COMPUTE_CAPABILITY
+from whichllm.constants import GPU_BANDWIDTH, NVIDIA_COMPUTE_CAPABILITY, _GiB
 from whichllm.hardware.types import GPUInfo
 
 logger = logging.getLogger(__name__)
+
+_NVIDIA_UNIFIED_MEMORY_MARKERS = ("GB10", "DGX SPARK")
 
 
 def _lookup_compute_capability(name: str) -> tuple[int, int] | None:
@@ -27,6 +29,42 @@ def _lookup_bandwidth(name: str) -> float | None:
         if key.upper() in name_upper:
             return GPU_BANDWIDTH[key]
     return None
+
+
+def _is_unified_memory_nvidia_gpu(name: str) -> bool:
+    name_upper = name.upper()
+    return any(marker in name_upper for marker in _NVIDIA_UNIFIED_MEMORY_MARKERS)
+
+
+def _system_memory_bytes() -> int:
+    from whichllm.hardware.memory import detect_ram_bytes
+
+    ram_bytes = detect_ram_bytes()
+    if ram_bytes > 0:
+        return ram_bytes
+    return 128 * _GiB
+
+
+def _make_nvidia_gpu(
+    name: str,
+    vram_bytes: int | None,
+    cuda_version: str | None = None,
+) -> GPUInfo:
+    shared_memory = _is_unified_memory_nvidia_gpu(name)
+    if shared_memory and (vram_bytes is None or vram_bytes <= 0):
+        vram_bytes = _system_memory_bytes()
+    elif vram_bytes is None:
+        vram_bytes = 0
+
+    return GPUInfo(
+        name=name,
+        vendor="nvidia",
+        vram_bytes=vram_bytes,
+        compute_capability=_lookup_compute_capability(name),
+        cuda_version=cuda_version,
+        memory_bandwidth_gbps=_lookup_bandwidth(name),
+        shared_memory=shared_memory,
+    )
 
 
 def _detect_nvidia_gpus_via_smi() -> list[GPUInfo]:
@@ -56,19 +94,14 @@ def _detect_nvidia_gpus_via_smi() -> list[GPUInfo]:
         name, memory_mib_text = parts
         match = re.search(r"\d+", memory_mib_text)
         if not match:
-            logger.debug(f"Could not parse nvidia-smi memory value: {line!r}")
+            if not _is_unified_memory_nvidia_gpu(name):
+                logger.debug(f"Could not parse nvidia-smi memory value: {line!r}")
+                continue
+            gpus.append(_make_nvidia_gpu(name, None))
             continue
 
         memory_mib = int(match.group(0))
-        gpus.append(
-            GPUInfo(
-                name=name,
-                vendor="nvidia",
-                vram_bytes=memory_mib * 1024**2,
-                compute_capability=_lookup_compute_capability(name),
-                memory_bandwidth_gbps=_lookup_bandwidth(name),
-            )
-        )
+        gpus.append(_make_nvidia_gpu(name, memory_mib * 1024**2))
 
     return gpus
 
@@ -104,18 +137,16 @@ def detect_nvidia_gpus() -> list[GPUInfo]:
             if isinstance(name, bytes):
                 name = name.decode("utf-8")
 
-            mem_info = pynvml.nvmlDeviceGetMemoryInfo(handle)
+            try:
+                mem_info = pynvml.nvmlDeviceGetMemoryInfo(handle)
+                vram_bytes = mem_info.total
+            except pynvml.NVMLError:
+                if not _is_unified_memory_nvidia_gpu(name):
+                    raise
+                logger.debug(f"NVML did not report dedicated memory for {name}")
+                vram_bytes = None
 
-            gpus.append(
-                GPUInfo(
-                    name=name,
-                    vendor="nvidia",
-                    vram_bytes=mem_info.total,
-                    compute_capability=_lookup_compute_capability(name),
-                    cuda_version=cuda_str,
-                    memory_bandwidth_gbps=_lookup_bandwidth(name),
-                )
-            )
+            gpus.append(_make_nvidia_gpu(name, vram_bytes, cuda_str))
     except pynvml.NVMLError as e:
         logger.debug(f"Error enumerating NVIDIA GPUs: {e}")
     finally:

--- a/tests/test_nvidia_detection.py
+++ b/tests/test_nvidia_detection.py
@@ -55,6 +55,79 @@ def test_nvidia_smi_fallback_when_nvml_init_fails(monkeypatch):
     assert gpus[0].name == "NVIDIA DGX Spark"
     assert gpus[0].vendor == "nvidia"
     assert gpus[0].vram_bytes == 128000 * 1024**2
+    assert gpus[0].shared_memory is True
+
+
+def test_nvidia_smi_fallback_detects_gb10_with_na_memory(monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "pynvml":
+            raise ImportError
+        return real_import(name, *args, **kwargs)
+
+    def fake_run(*args, **kwargs):
+        return SimpleNamespace(stdout="NVIDIA GB10, [N/A]\n")
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        "whichllm.hardware.memory.detect_ram_bytes", lambda: 128 * 1024**3
+    )
+
+    gpus = detect_nvidia_gpus()
+
+    assert len(gpus) == 1
+    assert gpus[0].name == "NVIDIA GB10"
+    assert gpus[0].vendor == "nvidia"
+    assert gpus[0].vram_bytes == 128 * 1024**3
+    assert gpus[0].shared_memory is True
+    assert gpus[0].compute_capability == (12, 1)
+    assert gpus[0].memory_bandwidth_gbps == 273.0
+
+
+def test_nvml_detects_gb10_when_memory_info_is_unavailable(monkeypatch):
+    class FakeNVMLError(Exception):
+        pass
+
+    handle = object()
+    fake_pynvml = SimpleNamespace(
+        NVMLError=FakeNVMLError,
+        nvmlInit=Mock(),
+        nvmlDeviceGetCount=Mock(return_value=1),
+        nvmlSystemGetDriverVersion=Mock(return_value=b"580.142"),
+        nvmlSystemGetCudaDriverVersion_v2=Mock(return_value=12010),
+        nvmlDeviceGetHandleByIndex=Mock(return_value=handle),
+        nvmlDeviceGetName=Mock(return_value="NVIDIA GB10"),
+        nvmlDeviceGetMemoryInfo=Mock(side_effect=FakeNVMLError("not supported")),
+        nvmlShutdown=Mock(),
+    )
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "pynvml":
+            return fake_pynvml
+        return real_import(name, *args, **kwargs)
+
+    def fake_run(*args, **kwargs):
+        raise AssertionError("nvidia-smi fallback should not be used")
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        "whichllm.hardware.memory.detect_ram_bytes", lambda: 128 * 1024**3
+    )
+
+    gpus = detect_nvidia_gpus()
+
+    assert len(gpus) == 1
+    assert gpus[0].name == "NVIDIA GB10"
+    assert gpus[0].vendor == "nvidia"
+    assert gpus[0].vram_bytes == 128 * 1024**3
+    assert gpus[0].shared_memory is True
+    assert gpus[0].compute_capability == (12, 1)
+    assert gpus[0].cuda_version == "12.1"
+    assert gpus[0].memory_bandwidth_gbps == 273.0
 
 
 def test_nvidia_smi_fallback_returns_empty_on_command_failure(monkeypatch):


### PR DESCRIPTION
Fixes #34

Summary
- Treat NVIDIA GB10 / DGX Spark as unified-memory NVIDIA GPUs.
- When NVML or nvidia-smi cannot report dedicated memory, use system RAM for fit checks and mark the GPU as shared memory.
- Add GB10 bandwidth and compute capability metadata, plus docs and regression coverage.

Tests
- ruff format --check src/whichllm/hardware/nvidia.py src/whichllm/constants.py tests/test_nvidia_detection.py
- ruff check src/whichllm/hardware/nvidia.py src/whichllm/constants.py tests/test_nvidia_detection.py
- git diff --check
- uv run pytest -q -s tests/test_nvidia_detection.py
- uv run pytest -q -s
