### PR TITLE
feat: support context length shorthand

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,7 +17,7 @@ Common options:
 | Option | Meaning |
 | --- | --- |
 | `--top`, `-n` | Number of ranked models to show. Default: `10` |
-| `--context-length`, `-c` | Context length used for KV cache estimation. Default: `4096` |
+| `--context-length`, `-c` | Context length used for KV cache estimation. Accepts integers or `k` shorthand such as `64k`. Default: `4096` |
 | `--quant`, `-q` | Keep only a quantization type such as `Q4_K_M` |
 | `--min-speed` | Keep only models above a tok/s estimate |
 | `--profile` | Ranking profile: `general`, `coding`, `vision`, `math`, `any` |
@@ -39,6 +39,7 @@ whichllm
 whichllm --gpu "RTX 4090"
 whichllm --gpu "RTX 5060 Ti" --vram 16
 whichllm --profile coding --top 5
+whichllm --context-length 64k
 whichllm --evidence strict
 whichllm --status
 whichllm --json | jq '.models[0]'
@@ -82,7 +83,7 @@ Options:
 
 | Option | Meaning |
 | --- | --- |
-| `--context-length`, `-c` | Context length for the memory estimate. Default: `4096` |
+| `--context-length`, `-c` | Context length for the memory estimate. Accepts integers or `k` shorthand such as `128k`. Default: `4096` |
 | `--quant`, `-q` | Target quantization. Default: `Q4_K_M` |
 | `--json` | Print the plan as JSON |
 | `--refresh` | Ignore model cache and fetch again |
@@ -93,6 +94,7 @@ Examples:
 whichllm plan "llama 3 70b"
 whichllm plan "Qwen2.5-72B" --quant Q8_0
 whichllm plan "mistral 7b" --context-length 32768
+whichllm plan "mistral 7b" --context-length 32k
 ```
 
 ## `upgrade`
@@ -108,7 +110,7 @@ Options:
 
 | Option | Meaning |
 | --- | --- |
-| `--context-length`, `-c` | Context length used for ranking. Default: `8192` |
+| `--context-length`, `-c` | Context length used for ranking. Accepts integers or `k` shorthand such as `64k`. Default: `8192` |
 | `--top`, `-n` | Best-N models to compare per GPU. Default: `3` |
 | `--profile` | Ranking profile. Default: `general` |
 | `--cpu-only` | Use CPU-only as the current baseline |
@@ -121,6 +123,7 @@ Examples:
 whichllm upgrade "RTX 4090" "RTX 5090" "H100"
 whichllm upgrade "Apple M4 Max" --top 5
 whichllm upgrade "RX 7900 XTX" --profile coding
+whichllm upgrade "RTX 4090" --context-length 128k
 ```
 
 ## `run`
@@ -140,7 +143,7 @@ Options:
 
 | Option | Meaning |
 | --- | --- |
-| `--context-length`, `-c` | Context length for the generated chat script |
+| `--context-length`, `-c` | Context length for the generated chat script. Accepts integers or `k` shorthand such as `64k` |
 | `--quant`, `-q` | Preferred GGUF quantization |
 | `--refresh` | Ignore model cache and fetch again |
 | `--cpu-only` | Force CPU-only execution in the generated script |
@@ -151,6 +154,7 @@ Examples:
 whichllm run
 whichllm run "qwen 2.5 1.5b gguf"
 whichllm run "phi 3 mini gguf" --cpu-only
+whichllm run "mistral 7b gguf" --context-length 64k
 ```
 
 `run` requires `uv` in `PATH`.

--- a/src/whichllm/cli.py
+++ b/src/whichllm/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 import sys
 from typing import Optional
 
@@ -77,6 +78,25 @@ def _resolve_evidence_mode(evidence: str, direct: bool) -> str:
         # 互換性維持のため --direct は strict と同義に固定する。
         return "strict"
     return mode
+
+
+def _parse_context_length(value: int | str) -> int:
+    """Parse context length, accepting shorthand like 64k for 65536."""
+    if isinstance(value, int):
+        return value
+
+    text = value.strip().replace("_", "").lower()
+    match = re.fullmatch(r"([1-9]\d*)(k?)", text)
+    if not match:
+        console.print(
+            "[red]Error:[/] context length must be a positive integer or use k shorthand, e.g. 64k."
+        )
+        raise typer.Exit(code=1)
+
+    amount = int(match.group(1))
+    if match.group(2) == "k":
+        return amount * 1024
+    return amount
 
 
 def _apply_gpu_overrides(
@@ -190,8 +210,11 @@ def main(
         False, "--refresh", help="Ignore cache and re-fetch models"
     ),
     top: int = typer.Option(10, "--top", "-n", help="Number of top models to show"),
-    context_length: int = typer.Option(
-        4096, "--context-length", "-c", help="Context length for KV cache estimation"
+    context_length: str = typer.Option(
+        "4096",
+        "--context-length",
+        "-c",
+        help="Context length for KV cache estimation (supports shorthand like 64k)",
     ),
     quant: Optional[str] = typer.Option(
         None, "--quant", "-q", help="Filter by quantization type (e.g. Q4_K_M)"
@@ -242,6 +265,7 @@ def main(
     _validate_gpu_flags(cpu_only, gpu, vram)
     profile = _validate_profile(profile)
     evidence_mode = _resolve_evidence_mode(evidence, direct)
+    context_length_int = _parse_context_length(context_length)
 
     from rich.progress import Progress, SpinnerColumn, TextColumn
 
@@ -329,7 +353,7 @@ def main(
         results = rank_models(
             all_models,
             hardware,
-            context_length=context_length,
+            context_length=context_length_int,
             top_n=top,
             quant_filter=quant,
             min_speed=min_speed,
@@ -345,7 +369,7 @@ def main(
             results = rank_models(
                 all_models,
                 hardware,
-                context_length=context_length,
+                context_length=context_length_int,
                 top_n=top,
                 quant_filter=quant,
                 min_speed=min_speed,
@@ -382,8 +406,11 @@ def main(
 @app.command()
 def plan(
     model_name: str = typer.Argument(..., help="Model name or HuggingFace repo ID"),
-    context_length: int = typer.Option(
-        4096, "--context-length", "-c", help="Context length for KV cache estimation"
+    context_length: str = typer.Option(
+        "4096",
+        "--context-length",
+        "-c",
+        help="Context length for KV cache estimation (supports shorthand like 64k)",
     ),
     quant: Optional[str] = typer.Option(
         None, "--quant", "-q", help="Target quantization (default: Q4_K_M)"
@@ -420,14 +447,15 @@ def plan(
                 sys.exit(1)
 
     model = _search_model(models, model_name)
+    context_length_int = _parse_context_length(context_length)
 
     target_quant = quant.upper() if quant else "Q4_K_M"
 
     if json_output:
-        display_plan_json(model, context_length, target_quant)
+        display_plan_json(model, context_length_int, target_quant)
     else:
         console.print()
-        display_plan(model, context_length, target_quant)
+        display_plan(model, context_length_int, target_quant)
         console.print()
 
 
@@ -437,8 +465,11 @@ def upgrade(
         ...,
         help="GPUs to compare against (e.g. 'RTX 4090' 'RTX 5090' 'H100')",
     ),
-    context_length: int = typer.Option(
-        8192, "--context-length", "-c", help="Context length for ranking"
+    context_length: str = typer.Option(
+        "8192",
+        "--context-length",
+        "-c",
+        help="Context length for ranking (supports shorthand like 64k)",
     ),
     top: int = typer.Option(3, "--top", "-n", help="Best-N models to compare per GPU"),
     profile: str = typer.Option("general", "--profile", help="Ranking profile"),
@@ -473,6 +504,7 @@ def upgrade(
     from whichllm.output.display import display_upgrade, display_upgrade_json
 
     profile = _validate_profile(profile)
+    context_length_int = _parse_context_length(context_length)
 
     with Progress(
         SpinnerColumn(),
@@ -517,7 +549,7 @@ def upgrade(
             results = rank_models(
                 all_models,
                 hw,
-                context_length=context_length,
+                context_length=context_length_int,
                 top_n=top,
                 benchmark_scores=bench_scores,
                 task_profile=profile,
@@ -528,7 +560,7 @@ def upgrade(
                 results = rank_models(
                     all_models,
                     hw,
-                    context_length=context_length,
+                    context_length=context_length_int,
                     top_n=top,
                     benchmark_scores=bench_scores,
                     task_profile=profile,
@@ -847,8 +879,11 @@ def run(
     model_name: Optional[str] = typer.Argument(
         None, help="Model to run (default: auto-pick best)"
     ),
-    context_length: int = typer.Option(
-        4096, "--context-length", "-c", help="Context length"
+    context_length: str = typer.Option(
+        "4096",
+        "--context-length",
+        "-c",
+        help="Context length (supports shorthand like 64k)",
     ),
     quant: Optional[str] = typer.Option(
         None, "--quant", "-q", help="Quantization type"
@@ -882,6 +917,7 @@ def run(
         progress.remove_task(task)
 
     variant = None
+    context_length_int = _parse_context_length(context_length)
     if model_name:
         model = _search_model(models, model_name)
     else:
@@ -903,7 +939,7 @@ def run(
         results = rank_models(
             all_models,
             hardware,
-            context_length=context_length,
+            context_length=context_length_int,
             top_n=5,
             quant_filter=quant,
             benchmark_scores=bench_scores,
@@ -959,7 +995,7 @@ def run(
     if variant is None:
         variant = _pick_gguf_variant(model, quant)
     deps, script_type = _resolve_model_deps(model, variant)
-    script = _generate_chat_script(model, variant, context_length, cpu_only)
+    script = _generate_chat_script(model, variant, context_length_int, cpu_only)
 
     fmt = variant.quant_type if variant else script_type.upper()
     console.print(f"\n[bold green]Running {model.id}[/] [dim]({fmt})[/]")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,7 @@ from whichllm.cli import (
     _generate_chat_script,
     _include_vision_candidates,
     _merge_model_eval_benchmarks,
+    _parse_context_length,
     _pick_gguf_variant,
     _resolve_ranked_gguf_for_run,
     _resolve_evidence_mode,
@@ -148,6 +149,20 @@ def test_validate_evidence_rejects_unknown_mode():
 
 def test_resolve_evidence_mode_direct_alias_wins():
     assert _resolve_evidence_mode("base", direct=True) == "strict"
+
+
+def test_parse_context_length_accepts_plain_integer_string():
+    assert _parse_context_length("32768") == 32768
+
+
+def test_parse_context_length_accepts_k_shorthand():
+    assert _parse_context_length("64k") == 64 * 1024
+    assert _parse_context_length("128K") == 128 * 1024
+
+
+def test_parse_context_length_rejects_invalid_shorthand():
+    with pytest.raises(Exit):
+        _parse_context_length("64kb")
 
 
 # --------------- plan command tests ---------------


### PR DESCRIPTION
## Summary
- add parsing for `--context-length` values like `64k` and `128k`
- apply the parser to ranking, plan, upgrade, and run commands
- document shorthand usage in the CLI reference

Closes #59.

## Verification
- `.venv/bin/python -m pytest tests/test_cli.py -q` -> 32 passed
- `.venv/bin/python -m pytest -q` -> 195 passed

## AI-assisted work
This patch was prepared with AI assistance and manually reviewed. The targeted tests were written first, observed failing before implementation, then the full test suite was run locally.