### PR TITLE
fix: update CONTRIBUTING.md dev setup to use uv

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,15 +7,13 @@ Thanks for your interest in contributing! Here's how you can help.
 ```bash
 git clone https://github.com/Andyyyy64/whichllm.git
 cd whichllm
-python -m venv .venv
-source .venv/bin/activate
-pip install -e ".[dev]"
+uv sync --dev
 ```
 
 ## Running Tests
 
 ```bash
-pytest
+uv run pytest
 ```
 
 ## How to Contribute
@@ -34,7 +32,7 @@ Open an issue describing the feature and why it would be useful.
 1. Fork the repository
 2. Create a feature branch (`git checkout -b feature/your-feature`)
 3. Make your changes
-4. Run tests (`pytest`)
+4. Run tests (`uv run pytest`)
 5. Submit a PR
 
 ### AI-assisted Contributions


### PR DESCRIPTION
## Summary

- CONTRIBUTING.md told contributors to run `pip install -e ".[dev]"`, but pyproject.toml defines dev dependencies under `[dependency-groups]` (PEP 735), not `[project.optional-dependencies]`. The pip command fails.
- Replaced with `uv sync --dev` and `uv run pytest` to match the README and the actual build system.

## Test plan

- [ ] Verify `uv sync --dev` installs dev deps correctly
- [ ] Verify `uv run pytest` runs the test suite