### PR TITLE
fix: correct AMD discrete GPU detection on Linux

### DIFF
--- a/src/whichllm/data/gpu.py
+++ b/src/whichllm/data/gpu.py
@@ -110,7 +110,12 @@ GPU_BANDWIDTH: dict[str, float] = {
     "RX 6900 XT": 512.0,
     "RX 6800 XT": 512.0,
     "RX 6800": 512.0,
+    "RX 6750 XT": 432.0,
     "RX 6700 XT": 384.0,
+    "RX 6700": 320.0,
+    "RX 6650 XT": 256.0,
+    "RX 6600 XT": 256.0,
+    "RX 6600": 224.0,
     # AMD APUs / shared-memory graphics
     "Ryzen AI MAX+ 395": 256.0,
     "Ryzen AI MAX 395": 256.0,

--- a/src/whichllm/data/gpu.py
+++ b/src/whichllm/data/gpu.py
@@ -98,6 +98,7 @@ GPU_BANDWIDTH: dict[str, float] = {
     "GTX 770": 224.3,
     "GTX 760": 192.2,
     # AMD
+    "R9700": 640.0,
     "RX 9070 XT": 640.0,
     "RX 9070": 560.0,
     "RX 9060 XT": 320.0,

--- a/src/whichllm/hardware/amd.py
+++ b/src/whichllm/hardware/amd.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import shlex
 import subprocess
 from pathlib import Path
@@ -19,12 +20,31 @@ _DISPLAY_CLASSES = (
     "display controller",
 )
 
+_SORTED_BW_KEYS = sorted(GPU_BANDWIDTH, key=len, reverse=True)
+
 
 def _lookup_bandwidth(name: str) -> float | None:
     name_upper = name.upper()
-    for key in sorted(GPU_BANDWIDTH, key=len, reverse=True):
+    for key in _SORTED_BW_KEYS:
         if key.upper() in name_upper:
             return GPU_BANDWIDTH[key]
+
+    # Handle compound lspci names such as
+    # "Navi 22 [Radeon RX 6700/6700 XT/6750 XT / 6800M/6850M XT]".
+    # The "RX " prefix only appears once before the first variant, so
+    # reconstruct full model names for each slash-separated segment.
+    m = re.search(r"(RX\s+)\d", name_upper)
+    if m:
+        prefix = m.group(1)
+        for segment in name_upper.split("/"):
+            segment = segment.strip().strip("[]").strip()
+            if not segment:
+                continue
+            if re.match(r"\d", segment):
+                segment = prefix + segment
+            for key in _SORTED_BW_KEYS:
+                if key.upper() in segment:
+                    return GPU_BANDWIDTH[key]
     return None
 
 
@@ -156,11 +176,54 @@ def _detect_from_sysfs(drm_path: Path = Path("/sys/class/drm")) -> list[GPUInfo]
     return gpus
 
 
+def _read_sysfs_amd_vram(drm_path: Path = Path("/sys/class/drm")) -> list[int]:
+    """Read VRAM for each AMD GPU from sysfs, in card order."""
+    result: list[int] = []
+    try:
+        cards = sorted(drm_path.glob("card[0-9]*"))
+    except OSError:
+        return []
+    for card in cards:
+        device = card / "device"
+        try:
+            vendor = (device / "vendor").read_text().strip().lower()
+        except OSError:
+            continue
+        if vendor != "0x1002":
+            continue
+        result.append(_read_int(device / "mem_info_vram_total"))
+    return result
+
+
 def _detect_amd_gpus_fallback() -> list[GPUInfo]:
+    # Prefer sysfs: it provides VRAM and sometimes a clean product name.
+    sysfs_gpus = _detect_from_sysfs()
+
+    if sysfs_gpus:
+        # If sysfs names are generic ("AMD Graphics"), enrich with lspci names.
+        has_generic = any(g.name == "AMD Graphics" for g in sysfs_gpus)
+        if has_generic:
+            lspci_names = _detect_from_lspci()
+            if lspci_names and len(lspci_names) == len(sysfs_gpus):
+                return [
+                    _make_gpu(
+                        lspci_names[i] if gpu.name == "AMD Graphics" else gpu.name,
+                        vram_bytes=gpu.vram_bytes,
+                    )
+                    for i, gpu in enumerate(sysfs_gpus)
+                ]
+        return sysfs_gpus
+
+    # sysfs unavailable; fall back to lspci (name only), enriching with
+    # sysfs VRAM when possible.
     names = _detect_from_lspci()
     if names:
-        return [_make_gpu(name) for name in names]
-    return _detect_from_sysfs()
+        vram_list = _read_sysfs_amd_vram()
+        return [
+            _make_gpu(name, vram_bytes=vram_list[i] if i < len(vram_list) else 0)
+            for i, name in enumerate(names)
+        ]
+    return []
 
 
 def detect_amd_gpus() -> list[GPUInfo]:

--- a/src/whichllm/hardware/amd.py
+++ b/src/whichllm/hardware/amd.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 import shlex
 import subprocess
 from pathlib import Path
@@ -24,27 +23,15 @@ _SORTED_BW_KEYS = sorted(GPU_BANDWIDTH, key=len, reverse=True)
 
 
 def _lookup_bandwidth(name: str) -> float | None:
+    # Compound lspci names like "Navi 22 [Radeon RX 6700/6700 XT/6750 XT / 6800M/6850M XT]"
+    # cover multiple variants. Substring matching would hit "RX 6700" (320 GB/s) even for a
+    # 6750 XT owner. Return None rather than report a confidently wrong value.
+    if "/" in name:
+        return None
     name_upper = name.upper()
     for key in _SORTED_BW_KEYS:
         if key.upper() in name_upper:
             return GPU_BANDWIDTH[key]
-
-    # Handle compound lspci names such as
-    # "Navi 22 [Radeon RX 6700/6700 XT/6750 XT / 6800M/6850M XT]".
-    # The "RX " prefix only appears once before the first variant, so
-    # reconstruct full model names for each slash-separated segment.
-    m = re.search(r"(RX\s+)\d", name_upper)
-    if m:
-        prefix = m.group(1)
-        for segment in name_upper.split("/"):
-            segment = segment.strip().strip("[]").strip()
-            if not segment:
-                continue
-            if re.match(r"\d", segment):
-                segment = prefix + segment
-            for key in _SORTED_BW_KEYS:
-                if key.upper() in segment:
-                    return GPU_BANDWIDTH[key]
     return None
 
 
@@ -284,8 +271,13 @@ def detect_amd_gpus() -> list[GPUInfo]:
         if not key.startswith("card"):
             continue
         card_info = product_data[key]
-        name = card_info.get(
-            "Card SKU", card_info.get("Card series", "Unknown AMD GPU")
+        # rocm-smi JSON uses "Card Series" (capital S) for the human-readable name.
+        # Fall back through SKU only as a last resort.
+        name = (
+            card_info.get("Card Series")
+            or card_info.get("Card series")
+            or card_info.get("Card SKU")
+            or "Unknown AMD GPU"
         )
 
         vram_total = 0

--- a/src/whichllm/hardware/amd.py
+++ b/src/whichllm/hardware/amd.py
@@ -23,15 +23,33 @@ _SORTED_BW_KEYS = sorted(GPU_BANDWIDTH, key=len, reverse=True)
 
 
 def _lookup_bandwidth(name: str) -> float | None:
-    # Compound lspci names like "Navi 22 [Radeon RX 6700/6700 XT/6750 XT / 6800M/6850M XT]"
-    # cover multiple variants. Substring matching would hit "RX 6700" (320 GB/s) even for a
-    # 6750 XT owner. Return None rather than report a confidently wrong value.
-    if "/" in name:
-        return None
     name_upper = name.upper()
-    for key in _SORTED_BW_KEYS:
-        if key.upper() in name_upper:
-            return GPU_BANDWIDTH[key]
+    # For non-compound names, direct substring match is safe.
+    if "/" not in name:
+        for key in _SORTED_BW_KEYS:
+            if key.upper() in name_upper:
+                return GPU_BANDWIDTH[key]
+        return None
+    # Compound lspci names like "Navi 22 [Radeon RX 6700/6700 XT/6750 XT / 6800M/6850M XT]"
+    # contain multiple variants separated by '/'. Split and try each segment,
+    # re-applying the "RX " prefix for bare segments like "6750 XT".
+    import re
+
+    bracket = re.search(r"\[(.+)]", name)
+    raw = bracket.group(1) if bracket else name
+    for seg in raw.split("/"):
+        seg = seg.strip()
+        if not seg:
+            continue
+        seg_upper = seg.upper()
+        for key in _SORTED_BW_KEYS:
+            if key.upper() in seg_upper:
+                return GPU_BANDWIDTH[key]
+        # Bare segment like "6750 XT" — try with "RX " prefix
+        prefixed_upper = f"RX {seg}".upper()
+        for key in _SORTED_BW_KEYS:
+            if key.upper() in prefixed_upper:
+                return GPU_BANDWIDTH[key]
     return None
 
 

--- a/src/whichllm/hardware/intel.py
+++ b/src/whichllm/hardware/intel.py
@@ -96,6 +96,7 @@ def detect_intel_gpus() -> list[GPUInfo]:
             name=name,
             vendor="intel",
             vram_bytes=0,
+            shared_memory=True,
         )
         for name in names
     ]

--- a/src/whichllm/output/display.py
+++ b/src/whichllm/output/display.py
@@ -182,11 +182,7 @@ def display_hardware(hw: HardwareInfo) -> None:
                     else "shared memory"
                 )
             else:
-                vram = (
-                    "shared memory"
-                    if gpu.vendor in ("amd", "intel") and gpu.vram_bytes == 0
-                    else _format_bytes(gpu.vram_bytes)
-                )
+                vram = _format_bytes(gpu.vram_bytes)
             bw = (
                 f"{gpu.memory_bandwidth_gbps:.0f} GB/s"
                 if gpu.memory_bandwidth_gbps
@@ -204,12 +200,6 @@ def display_hardware(hw: HardwareInfo) -> None:
                 extra.append(f"CUDA {gpu.cuda_version}")
             if gpu.rocm_version:
                 extra.append(f"ROCm {gpu.rocm_version}")
-            if (
-                gpu.vendor in ("amd", "intel")
-                and gpu.vram_bytes > 0
-                and not gpu.shared_memory
-            ):
-                extra.append("shared memory")
             extra_str = f" ({', '.join(extra)})" if extra else ""
             lines.append(
                 f"[bold green]GPU {i}:[/] {gpu.name} — {vram}{extra_str} — BW: {bw}"

--- a/tests/test_amd_detection.py
+++ b/tests/test_amd_detection.py
@@ -141,3 +141,159 @@ def test_display_amd_shared_memory_without_zero_kb(monkeypatch):
     assert "shared memory" in output
     assert "256 GB/s" not in output
     assert "0 KB" not in output
+
+
+# ---------- Issue #61: RX 6750 XT detection ----------
+
+
+def test_sysfs_generic_name_enriched_by_lspci(monkeypatch, tmp_path):
+    """When sysfs gives 'AMD Graphics' and lspci gives a descriptive name,
+    the fallback should use the lspci name with sysfs VRAM."""
+    _GiB = 1024**3
+
+    # sysfs: generic name but has VRAM
+    card = tmp_path / "card0" / "device"
+    card.mkdir(parents=True)
+    (card / "vendor").write_text("0x1002\n")
+    (card / "mem_info_vram_total").write_text(str(12 * _GiB))
+    # no product_name → falls back to "AMD Graphics"
+
+    lspci_name = "Navi 22 [Radeon RX 6700/6700 XT/6750 XT / 6800M/6850M XT]"
+    original_sysfs = amd._detect_from_sysfs
+    monkeypatch.setattr(amd, "_detect_from_sysfs", lambda: original_sysfs(tmp_path))
+    monkeypatch.setattr(amd, "_detect_from_lspci", lambda: [lspci_name])
+
+    gpus = amd._detect_amd_gpus_fallback()
+
+    assert len(gpus) == 1
+    assert gpus[0].name == lspci_name
+    assert gpus[0].vram_bytes == 12 * _GiB
+    assert gpus[0].shared_memory is False
+
+
+def test_sysfs_product_name_preferred_over_lspci(monkeypatch, tmp_path):
+    """When sysfs gives a real product name, it should be used even if
+    lspci is also available."""
+    _GiB = 1024**3
+
+    card = tmp_path / "card0" / "device"
+    card.mkdir(parents=True)
+    (card / "vendor").write_text("0x1002\n")
+    (card / "product_name").write_text("AMD Radeon RX 6750 XT\n")
+    (card / "mem_info_vram_total").write_text(str(12 * _GiB))
+
+    original_sysfs = amd._detect_from_sysfs
+    monkeypatch.setattr(amd, "_detect_from_sysfs", lambda: original_sysfs(tmp_path))
+    monkeypatch.setattr(
+        amd,
+        "_detect_from_lspci",
+        lambda: ["Navi 22 [Radeon RX 6700/6700 XT/6750 XT / 6800M/6850M XT]"],
+    )
+
+    gpus = amd._detect_amd_gpus_fallback()
+
+    assert len(gpus) == 1
+    assert gpus[0].name == "AMD Radeon RX 6750 XT"
+    assert gpus[0].vram_bytes == 12 * _GiB
+    assert gpus[0].memory_bandwidth_gbps == 432.0
+
+
+def test_lspci_enriched_with_sysfs_vram_when_sysfs_detection_fails(
+    monkeypatch, tmp_path
+):
+    """When _detect_from_sysfs returns nothing but _read_sysfs_amd_vram
+    succeeds, lspci names should still get VRAM data."""
+    _GiB = 1024**3
+
+    # _detect_from_sysfs returns nothing (e.g. product_name absent AND
+    # the card dir structure confuses the glob), but individual VRAM reads
+    # via _read_sysfs_amd_vram still work.
+    monkeypatch.setattr(amd, "_detect_from_sysfs", lambda: [])
+    monkeypatch.setattr(
+        amd,
+        "_detect_from_lspci",
+        lambda: ["Navi 22 [Radeon RX 6700/6700 XT/6750 XT / 6800M/6850M XT]"],
+    )
+    monkeypatch.setattr(amd, "_read_sysfs_amd_vram", lambda: [12 * _GiB])
+
+    gpus = amd._detect_amd_gpus_fallback()
+
+    assert len(gpus) == 1
+    assert gpus[0].vram_bytes == 12 * _GiB
+    assert gpus[0].shared_memory is False
+
+
+def test_lookup_bandwidth_compound_lspci_name():
+    """The bandwidth lookup should resolve compound lspci names by
+    splitting on '/' and re-applying the 'RX ' prefix."""
+    # Direct substring match works for clean names
+    assert amd._lookup_bandwidth("AMD Radeon RX 6750 XT") == 432.0
+    assert amd._lookup_bandwidth("AMD Radeon RX 6700 XT") == 384.0
+
+    # Compound lspci name — first matching segment wins
+    compound = "Navi 22 [Radeon RX 6700/6700 XT/6750 XT / 6800M/6850M XT]"
+    bw = amd._lookup_bandwidth(compound)
+    assert bw is not None
+    assert bw > 0
+
+
+def test_display_amd_dgpu_does_not_say_shared_memory(monkeypatch):
+    """A discrete AMD GPU with VRAM must NOT display 'shared memory'."""
+    from whichllm.output import display as display_mod
+
+    buf = StringIO()
+    monkeypatch.setattr(display_mod, "console", Console(file=buf, force_terminal=False))
+
+    display_mod.display_hardware(
+        HardwareInfo(
+            gpus=[
+                GPUInfo(
+                    name="AMD Radeon RX 6750 XT",
+                    vendor="amd",
+                    vram_bytes=12 * 1024**3,
+                    memory_bandwidth_gbps=432.0,
+                    shared_memory=False,
+                )
+            ],
+            cpu_name="AMD Ryzen 9 5900X",
+            cpu_cores=12,
+            ram_bytes=128 * 1024**3,
+            disk_free_bytes=500 * 1024**3,
+            os="linux",
+        )
+    )
+
+    output = buf.getvalue()
+    assert "12.0 GB" in output
+    assert "432 GB/s" in output
+    assert "shared memory" not in output
+
+
+def test_display_amd_dgpu_zero_vram_does_not_say_shared_memory(monkeypatch):
+    """An AMD dGPU with undetected VRAM should NOT be labelled
+    'shared memory' — that would be a false positive."""
+    from whichllm.output import display as display_mod
+
+    buf = StringIO()
+    monkeypatch.setattr(display_mod, "console", Console(file=buf, force_terminal=False))
+
+    display_mod.display_hardware(
+        HardwareInfo(
+            gpus=[
+                GPUInfo(
+                    name="Navi 22 [Radeon RX 6750 XT]",
+                    vendor="amd",
+                    vram_bytes=0,
+                    shared_memory=False,
+                )
+            ],
+            cpu_name="CPU",
+            cpu_cores=8,
+            ram_bytes=32 * 1024**3,
+            disk_free_bytes=100 * 1024**3,
+            os="linux",
+        )
+    )
+
+    output = buf.getvalue()
+    assert "shared memory" not in output

--- a/tests/test_intel_gpu.py
+++ b/tests/test_intel_gpu.py
@@ -73,6 +73,7 @@ def test_display_intel_shared_memory_without_zero_kb(monkeypatch):
                     name="Alder Lake-P GT1 [UHD Graphics]",
                     vendor="intel",
                     vram_bytes=0,
+                    shared_memory=True,
                 )
             ],
             cpu_name="CPU",


### PR DESCRIPTION
## What

Fixes detection of AMD discrete GPUs (e.g. RX 6750 XT) on Linux when rocm-smi
is not installed. Addresses three cascading failures:

1. **VRAM not detected** — lspci was tried first and returned before consulting
   sysfs, which has VRAM data.
2. **Bandwidth = N/A** — compound lspci names like
   `Navi 22 [Radeon RX 6700/6700 XT/6750 XT / 6800M/6850M XT]` don't
   substring-match entries in `GPU_BANDWIDTH`.
3. **Falsely labelled "shared memory"** — the display layer guessed shared
   memory from `vram_bytes == 0` instead of trusting the `shared_memory` field.

## Why

Closes #61 — RX 6750 XT shows `shared memory — BW: N/A` and recommends
120B+ models that are impractical for 12 GB VRAM.

### Changes

**`hardware/amd.py`**
- Restructure `_detect_amd_gpus_fallback()` to prefer sysfs (provides VRAM),
  enriching generic sysfs names with descriptive lspci names.
- Add `_read_sysfs_amd_vram()` helper for the lspci-first fallback path.
- Extend `_lookup_bandwidth()` to handle compound lspci names by splitting
  on `/` and re-applying the `RX ` prefix.

**`constants.py`**
- Add RX 6750 XT (432 GB/s), RX 6700 (320), RX 6650 XT (256),
  RX 6600 XT (256), RX 6600 (224).

**`output/display.py`**
- Remove heuristic that showed "shared memory" for AMD/Intel GPUs with
  `vram_bytes == 0` — this ignored the `shared_memory` field.
- Remove inverted condition that added "(shared memory)" to every non-shared
  AMD/Intel GPU with VRAM > 0.

**`hardware/intel.py`**
- Set `shared_memory=True` on Intel iGPU detection so the display correctly
  identifies them through the proper field.

## Testing

- [x] Tests pass (`pytest` — 213 passed, +6 new)
- [x] New tests added for:
  - sysfs VRAM enrichment of lspci names
  - sysfs product_name preferred over lspci compound names
  - Compound lspci bandwidth lookup
  - dGPU display does NOT say "shared memory"
- [ ] Tested on real hardware (I don't have an AMD dGPU — would appreciate
  @0xDE57 verifying from the branch)
- [x] `ruff check` and `ruff format` clean