### PR TITLE
fix: detect Apple Silicon CPU and GPU on Asahi Linux

### DIFF
--- a/src/whichllm/hardware/apple.py
+++ b/src/whichllm/hardware/apple.py
@@ -1,10 +1,12 @@
-"""Apple Silicon detection via system_profiler."""
+"""Apple Silicon detection via system_profiler (macOS) and sysfs (Asahi Linux)."""
 
 from __future__ import annotations
 
 import json
 import logging
+import re
 import subprocess
+from pathlib import Path
 
 from whichllm.constants import GPU_BANDWIDTH
 from whichllm.hardware.types import GPUInfo
@@ -66,3 +68,64 @@ def detect_apple_gpu() -> list[GPUInfo]:
     except (KeyError, IndexError, ValueError) as e:
         logger.debug(f"Failed to parse Apple hardware info: {e}")
         return []
+
+
+# ---- Asahi Linux (Apple Silicon on Linux) ----
+
+_ASAHI_DRIVER_NAMES = ("asahi", "apple")
+
+
+def _chip_name_from_devicetree() -> str | None:
+    """Extract Apple chip name from Linux device tree."""
+    try:
+        raw = Path("/sys/firmware/devicetree/base/model").read_bytes()
+        model = raw.decode("utf-8", errors="replace").strip().rstrip("\x00")
+        if not model:
+            return None
+        m = re.search(r"\b(M\d+(?:\s+(?:Pro|Max|Ultra))?)\b", model)
+        if m:
+            return f"Apple {m.group(1)}"
+        return model
+    except OSError:
+        return None
+
+
+def detect_apple_gpu_linux(
+    drm_path: Path = Path("/sys/class/drm"),
+) -> list[GPUInfo]:
+    """Detect Apple Silicon GPU on Linux (Asahi driver).
+
+    Returns empty list when no Asahi/Apple DRM device is found.
+    """
+    try:
+        cards = sorted(drm_path.glob("card[0-9]*"))
+    except OSError:
+        return []
+
+    for card in cards:
+        driver = card / "device" / "driver"
+        try:
+            driver_name = driver.resolve().name
+        except OSError:
+            continue
+        if driver_name not in _ASAHI_DRIVER_NAMES:
+            continue
+
+        chip_name = _chip_name_from_devicetree() or "Apple Silicon"
+
+        # Unified memory — total system RAM is shared with the GPU.
+        import psutil
+
+        unified_memory = psutil.virtual_memory().total
+
+        return [
+            GPUInfo(
+                name=chip_name,
+                vendor="apple",
+                vram_bytes=unified_memory,
+                memory_bandwidth_gbps=_lookup_bandwidth(chip_name),
+                shared_memory=True,
+            )
+        ]
+
+    return []

--- a/src/whichllm/hardware/cpu.py
+++ b/src/whichllm/hardware/cpu.py
@@ -4,9 +4,42 @@ from __future__ import annotations
 
 import logging
 import platform
+import re
 import subprocess
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+
+def _cpu_name_from_lscpu() -> str | None:
+    """Try to get CPU model name from lscpu (works on ARM/aarch64)."""
+    try:
+        result = subprocess.run(["lscpu"], capture_output=True, text=True, timeout=5)
+        if result.returncode == 0:
+            for line in result.stdout.splitlines():
+                if line.strip().startswith("Model name"):
+                    name = line.split(":", 1)[1].strip()
+                    if name and name != "-":
+                        return name
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return None
+
+
+def _cpu_name_from_devicetree() -> str | None:
+    """Extract CPU/chip name from device tree (ARM Linux, Asahi)."""
+    try:
+        raw = Path("/sys/firmware/devicetree/base/model").read_bytes()
+        model = raw.decode("utf-8", errors="replace").strip().rstrip("\x00")
+        if not model:
+            return None
+        # "Apple MacBook Air (M2, 2022)" → "Apple M2"
+        m = re.search(r"\b(M\d+(?:\s+(?:Pro|Max|Ultra))?)\b", model)
+        if m:
+            return f"Apple {m.group(1)}"
+        return model
+    except OSError:
+        return None
 
 
 def detect_cpu_name() -> str:
@@ -18,6 +51,11 @@ def detect_cpu_name() -> str:
                 for line in f:
                     if line.startswith("model name"):
                         return line.split(":", 1)[1].strip()
+            # ARM/aarch64: /proc/cpuinfo has no model name field.
+            # Try lscpu, then device tree.
+            name = _cpu_name_from_lscpu() or _cpu_name_from_devicetree()
+            if name:
+                return name
         elif system == "Darwin":
             result = subprocess.run(
                 ["sysctl", "-n", "machdep.cpu.brand_string"],

--- a/src/whichllm/hardware/detector.py
+++ b/src/whichllm/hardware/detector.py
@@ -6,7 +6,7 @@ import logging
 import platform
 
 from whichllm.hardware.amd import detect_amd_gpus
-from whichllm.hardware.apple import detect_apple_gpu
+from whichllm.hardware.apple import detect_apple_gpu, detect_apple_gpu_linux
 from whichllm.hardware.cpu import detect_avx_support, detect_cpu_cores, detect_cpu_name
 from whichllm.hardware.intel import detect_intel_gpus
 from whichllm.hardware.memory import detect_disk_free_bytes, detect_ram_bytes
@@ -29,6 +29,7 @@ def detect_hardware() -> HardwareInfo:
     if os_name == "linux":
         gpus.extend(detect_amd_gpus())
         gpus.extend(detect_intel_gpus())
+        gpus.extend(detect_apple_gpu_linux())
     if os_name == "darwin":
         gpus.extend(detect_apple_gpu())
     if os_name == "windows":

--- a/tests/test_asahi_detection.py
+++ b/tests/test_asahi_detection.py
@@ -1,0 +1,213 @@
+"""Tests for Asahi Linux (Apple Silicon on Linux) detection — Issue #29."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from whichllm.hardware import apple, cpu
+
+
+# ---- CPU name fallback for ARM Linux ----
+
+
+def test_cpu_name_lscpu_fallback(monkeypatch):
+    """When /proc/cpuinfo has no model name (ARM), lscpu should be tried."""
+    # Simulate ARM /proc/cpuinfo (no model name field)
+    arm_cpuinfo = (
+        "processor\t: 0\n"
+        "BogoMIPS\t: 48.00\n"
+        "Features\t: fp asimd evtstrm aes\n"
+        "CPU implementer\t: 0x61\n"
+    )
+    monkeypatch.setattr("builtins.open", _fake_open(arm_cpuinfo))
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+
+    lscpu_output = "Architecture:            aarch64\nModel name:            Apple M2\n"
+
+    def fake_run(args, **kwargs):
+        if args == ["lscpu"]:
+            return subprocess.CompletedProcess(args, 0, stdout=lscpu_output, stderr="")
+        raise FileNotFoundError
+
+    monkeypatch.setattr(cpu.subprocess, "run", fake_run)
+
+    assert cpu.detect_cpu_name() == "Apple M2"
+
+
+def test_cpu_name_devicetree_fallback(monkeypatch, tmp_path):
+    """When lscpu also fails, device tree model should be used."""
+    arm_cpuinfo = "processor\t: 0\nFeatures\t: fp asimd\n"
+    monkeypatch.setattr("builtins.open", _fake_open(arm_cpuinfo))
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+
+    # lscpu not available
+    def fake_run(args, **kwargs):
+        raise FileNotFoundError
+
+    monkeypatch.setattr(cpu.subprocess, "run", fake_run)
+
+    # Device tree has the machine model
+    dt_model = tmp_path / "model"
+    dt_model.write_bytes(b"Apple MacBook Air (M2, 2022)\x00")
+    monkeypatch.setattr(
+        cpu, "_cpu_name_from_devicetree", lambda: _read_dt_model(dt_model)
+    )
+
+    assert cpu.detect_cpu_name() == "Apple M2"
+
+
+def test_cpu_name_devicetree_extracts_chip_variants():
+    """Verify chip name extraction from various device tree model strings."""
+    assert _extract("Apple MacBook Air (M2, 2022)") == "Apple M2"
+    assert _extract("Apple Mac Mini (M4 Pro, 2024)") == "Apple M4 Pro"
+    assert _extract("Apple Mac Studio (M2 Ultra, 2023)") == "Apple M2 Ultra"
+    assert _extract("Apple Mac Pro (M2 Max, 2023)") == "Apple M2 Max"
+    assert _extract("Apple MacBook Pro (M1, 2020)") == "Apple M1"
+
+
+def test_cpu_name_devicetree_non_apple():
+    """Non-Apple device tree models should not produce an Apple chip name."""
+    assert _extract("Raspberry Pi 4 Model B Rev 1.5") is None
+    assert _extract("Qualcomm Snapdragon 8cx Gen 3") is None
+
+
+def test_cpu_name_lscpu_ignores_dash(monkeypatch):
+    """lscpu returning '-' as the model name should be ignored."""
+    arm_cpuinfo = "processor\t: 0\n"
+    monkeypatch.setattr("builtins.open", _fake_open(arm_cpuinfo))
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+
+    lscpu_output = "Architecture:            aarch64\nModel name:            -\n"
+
+    def fake_run(args, **kwargs):
+        if args == ["lscpu"]:
+            return subprocess.CompletedProcess(args, 0, stdout=lscpu_output, stderr="")
+        raise FileNotFoundError
+
+    monkeypatch.setattr(cpu.subprocess, "run", fake_run)
+    monkeypatch.setattr(cpu, "_cpu_name_from_devicetree", lambda: "Apple M2")
+
+    assert cpu.detect_cpu_name() == "Apple M2"
+
+
+# ---- Apple GPU detection on Asahi Linux ----
+
+
+def test_detect_asahi_gpu_from_sysfs(monkeypatch, tmp_path):
+    """Asahi DRM driver should be detected and produce an Apple GPUInfo."""
+    _setup_asahi_sysfs(tmp_path)
+    monkeypatch.setattr(
+        apple,
+        "_chip_name_from_devicetree",
+        lambda: "Apple M2",
+    )
+    monkeypatch.setattr("psutil.virtual_memory", _fake_vmem(24 * 1024**3))
+
+    gpus = apple.detect_apple_gpu_linux(drm_path=tmp_path)
+
+    assert len(gpus) == 1
+    assert gpus[0].vendor == "apple"
+    assert gpus[0].name == "Apple M2"
+    assert gpus[0].vram_bytes == 24 * 1024**3
+    assert gpus[0].shared_memory is True
+    assert gpus[0].memory_bandwidth_gbps == 100.0  # M2 bandwidth
+
+
+def test_detect_asahi_gpu_fallback_name(monkeypatch, tmp_path):
+    """When device tree is unavailable, GPU should be named 'Apple Silicon'."""
+    _setup_asahi_sysfs(tmp_path)
+    monkeypatch.setattr(apple, "_chip_name_from_devicetree", lambda: None)
+    monkeypatch.setattr("psutil.virtual_memory", _fake_vmem(8 * 1024**3))
+
+    gpus = apple.detect_apple_gpu_linux(drm_path=tmp_path)
+
+    assert len(gpus) == 1
+    assert gpus[0].name == "Apple Silicon"
+
+
+def test_detect_asahi_gpu_ignores_non_apple_drivers(tmp_path):
+    """Non-Apple DRM drivers should not be detected as Apple GPUs."""
+    card = tmp_path / "card0" / "device" / "driver"
+    card.mkdir(parents=True)
+    # Symlink to a non-Apple driver name
+    target = tmp_path / "drivers" / "amdgpu"
+    target.mkdir(parents=True)
+    (tmp_path / "card0" / "device" / "driver").rmdir()
+    (tmp_path / "card0" / "device" / "driver").symlink_to(target)
+
+    assert apple.detect_apple_gpu_linux(drm_path=tmp_path) == []
+
+
+def test_detect_asahi_gpu_no_drm(tmp_path):
+    """When /sys/class/drm doesn't exist, return empty."""
+    nonexistent = tmp_path / "no_drm"
+    assert apple.detect_apple_gpu_linux(drm_path=nonexistent) == []
+
+
+# ---- Helpers ----
+
+
+def _setup_asahi_sysfs(tmp_path: Path) -> None:
+    """Create a minimal sysfs tree mimicking the Asahi DRM driver."""
+    device_dir = tmp_path / "card0" / "device"
+    device_dir.mkdir(parents=True)
+    # Symlink driver → .../asahi
+    driver_target = tmp_path / "drivers" / "asahi"
+    driver_target.mkdir(parents=True)
+    (device_dir / "driver").symlink_to(driver_target)
+
+
+def _fake_open(content: str):
+    """Return a context manager that yields lines from *content*
+    when the path is /proc/cpuinfo, and delegates otherwise."""
+    import builtins
+    import io
+
+    real_open = builtins.open
+
+    def patched_open(path, *a, **kw):
+        if str(path) == "/proc/cpuinfo":
+            return io.StringIO(content)
+        return real_open(path, *a, **kw)
+
+    return patched_open
+
+
+def _fake_vmem(total: int):
+    """Return a callable that mimics psutil.virtual_memory()."""
+    from collections import namedtuple
+
+    Vmem = namedtuple("svmem", ["total"])
+
+    def _inner():
+        return Vmem(total=total)
+
+    return _inner
+
+
+def _read_dt_model(path: Path) -> str | None:
+    """Simulate _cpu_name_from_devicetree reading from a custom path."""
+    import re
+
+    try:
+        raw = path.read_bytes()
+        model = raw.decode("utf-8", errors="replace").strip().rstrip("\x00")
+        if not model:
+            return None
+        m = re.search(r"\b(M\d+(?:\s+(?:Pro|Max|Ultra))?)\b", model)
+        if m:
+            return f"Apple {m.group(1)}"
+        return model
+    except OSError:
+        return None
+
+
+def _extract(model: str) -> str | None:
+    """Run the chip-name regex against a model string."""
+    import re
+
+    m = re.search(r"\b(M\d+(?:\s+(?:Pro|Max|Ultra))?)\b", model)
+    if m:
+        return f"Apple {m.group(1)}"
+    return None


### PR DESCRIPTION
## What

Adds CPU and GPU detection for Apple Silicon running Linux (Asahi/Fedora).
Currently both go undetected, producing:

```
No GPU detected — CPU-only mode
CPU: Unknown CPU — 8 cores
```

## Why

Closes #29 — M2 MacBook Air on Asahi Linux shows "Unknown CPU" and no GPU.

### Changes

**CPU detection (`hardware/cpu.py`)**
- Add `_cpu_name_from_lscpu()`: parses `Model name` from `lscpu` output
  (works on ARM/aarch64 with util-linux >= 2.39).
- Add `_cpu_name_from_devicetree()`: reads
  `/sys/firmware/devicetree/base/model` and extracts the Apple chip name
  (e.g., `Apple MacBook Air (M2, 2022)` → `Apple M2`).
- Fallback chain: `/proc/cpuinfo` → `lscpu` → device tree → `"Unknown CPU"`.

**GPU detection (`hardware/apple.py`)**
- Add `detect_apple_gpu_linux()`: scans `/sys/class/drm` for cards using
  the `asahi` or `apple` DRM driver.
- Reports unified memory (total system RAM), bandwidth from the existing
  `GPU_BANDWIDTH` table, and `shared_memory=True`.
- Add `_chip_name_from_devicetree()` to resolve the chip name on Linux.

**Orchestrator (`hardware/detector.py`)**
- Call `detect_apple_gpu_linux()` in the Linux detection block.

### Expected output after fix

```
GPU 0: Apple M2 — 23.2 GB shared — BW: 100 GB/s
CPU: Apple M2 — 8 cores
```

## Testing

- [x] Tests pass (`pytest` — 216 passed, +9 new)
- [x] New tests added for:
  - CPU lscpu fallback on ARM
  - CPU device tree fallback with chip name extraction
  - lscpu returning "-" is ignored
  - Non-Apple device tree models don't produce false Apple names
  - Asahi GPU detection from sysfs driver symlink
  - Fallback GPU name when device tree unavailable
  - Non-Apple DRM drivers are ignored
- [ ] Tested on real hardware (I don't have Asahi Linux — would appreciate
  @nicolasmaia verifying from the branch)
- [x] `ruff check` and `ruff format` clean

## Notes

- The Asahi DRM driver is currently named `asahi` but may be renamed to
  `apple` in upstream kernels; both names are accepted.
- On Asahi, the GPU uses Vulkan via Mesa, not Metal. Performance estimation
  may need separate tuning in a future PR, but detecting the hardware
  correctly is the prerequisite.