### PR TITLE
fix: import Exit from typer instead of click in test_cli

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
 """Tests for CLI helper logic."""
 
 import pytest
-from click.exceptions import Exit
+from typer import Exit
 
 import whichllm.cli as cli_mod
 from whichllm.cli import (


### PR DESCRIPTION
## What

Changes `from click.exceptions import Exit` to `from typer import Exit` in `tests/test_cli.py`.

## Why

Closes #70

`cli.py` raises `typer.Exit(code=1)`. When typer vendors click internally (as `typer._click`), `typer.Exit` becomes `typer._click.exceptions.Exit`. The test imported `Exit` from `click.exceptions` directly, which is a different class in that scenario, so `pytest.raises(Exit)` did not catch it.

This surfaces on CI because `test.yml` installs via `pip install -e .` without a lockfile, so the resolved typer version varies across runs.

## Testing

- [x] Tests pass (`pytest`)
- [x] `ruff check` and `ruff format` clean