### PR TITLE
fix(ranker): demote models that cannot hold requested context

### DIFF
--- a/src/whichllm/engine/compatibility.py
+++ b/src/whichllm/engine/compatibility.py
@@ -114,7 +114,16 @@ def check_compatibility(
         warnings.append("Insufficient memory (GPU VRAM + RAM) to run this model")
 
     # Context length warning
-    if (
+    context_fits = not (
+        model.context_length is not None
+        and model.context_length < context_length
+    )
+    if not context_fits:
+        warnings.append(
+            f"Model max context {model.context_length} < requested "
+            f"{context_length}; runtime will truncate or reject"
+        )
+    elif (
         context_length > 8192
         and model.context_length
         and model.context_length >= context_length
@@ -137,4 +146,5 @@ def check_compatibility(
         vram_available_bytes=vram_available,
         warnings=warnings,
         fit_type=fit_type,
+        context_fits=context_fits,
     )

--- a/src/whichllm/engine/compatibility.py
+++ b/src/whichllm/engine/compatibility.py
@@ -115,8 +115,7 @@ def check_compatibility(
 
     # Context length warning
     context_fits = not (
-        model.context_length is not None
-        and model.context_length < context_length
+        model.context_length is not None and model.context_length < context_length
     )
     if not context_fits:
         warnings.append(

--- a/src/whichllm/engine/ranker.py
+++ b/src/whichllm/engine/ranker.py
@@ -61,7 +61,8 @@ def _family_selection_key(
         direct_bonus = 5.0
     else:
         direct_bonus = 0.0
-    return (result.quality_score + fit_bonus + direct_bonus,)
+    ctx_penalty = -20.0 if not result.context_fits else 0.0
+    return (result.quality_score + fit_bonus + direct_bonus + ctx_penalty,)
 
 
 # Per-source benchmark weight applied to the raw 0-100 score before it is

--- a/src/whichllm/engine/types.py
+++ b/src/whichllm/engine/types.py
@@ -22,3 +22,4 @@ class CompatibilityResult:
     benchmark_status: str = "none"  # "direct" | "estimated" | "self_reported" | "none"
     benchmark_source: str = "none"  # granular: "direct" | "variant" | "base_model" | "line_interp" | "self_reported" | "none"
     benchmark_confidence: float = 0.0  # 0.0-1.0 from BenchmarkEvidence
+    context_fits: bool = True  # False when known model max context < requested

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -5,12 +5,13 @@ from whichllm.hardware.types import GPUInfo, HardwareInfo
 from whichllm.models.types import GGUFVariant, ModelInfo
 
 
-def _make_model(params: int = 7_000_000_000) -> ModelInfo:
+def _make_model(params: int = 7_000_000_000, context_length: int | None = None) -> ModelInfo:
     return ModelInfo(
         id="test/model",
         family_id="test/model",
         name="model",
         parameter_count=params,
+        context_length=context_length,
     )
 
 
@@ -280,3 +281,29 @@ def test_insufficient_disk():
     result = check_compatibility(model, variant, hw)
     assert result.can_run is False
     assert any("disk" in w.lower() for w in result.warnings)
+
+
+def test_context_fits_true_when_model_supports():
+    model = _make_model(context_length=131072)
+    variant = _make_variant()
+    hw = _make_hardware(vram=24 * 1024**3)
+    result = check_compatibility(model, variant, hw, context_length=32768)
+    assert result.context_fits is True
+
+
+def test_context_fits_false_when_model_too_small():
+    model = _make_model(context_length=8192)
+    variant = _make_variant()
+    hw = _make_hardware(vram=24 * 1024**3)
+    result = check_compatibility(model, variant, hw, context_length=32768)
+    assert result.context_fits is False
+    assert any("max context" in w.lower() for w in result.warnings)
+
+
+def test_context_fits_unknown_is_true():
+    model = _make_model(context_length=None)
+    variant = _make_variant()
+    hw = _make_hardware(vram=24 * 1024**3)
+    result = check_compatibility(model, variant, hw, context_length=32768)
+    assert result.context_fits is True
+    assert not any("max context" in w.lower() for w in result.warnings)

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -5,7 +5,9 @@ from whichllm.hardware.types import GPUInfo, HardwareInfo
 from whichllm.models.types import GGUFVariant, ModelInfo
 
 
-def _make_model(params: int = 7_000_000_000, context_length: int | None = None) -> ModelInfo:
+def _make_model(
+    params: int = 7_000_000_000, context_length: int | None = None
+) -> ModelInfo:
     return ModelInfo(
         id="test/model",
         family_id="test/model",

--- a/tests/test_ranker.py
+++ b/tests/test_ranker.py
@@ -672,3 +672,60 @@ def test_benchmark_source_and_confidence_exposed_for_none():
     assert results[0].benchmark_status == "none"
     assert results[0].benchmark_source == "none"
     assert results[0].benchmark_confidence == 0.0
+
+
+def test_ctx_penalty_demotes_non_fitting():
+    models = [
+        ModelInfo(
+            id="org/LongCtx-8B",
+            family_id="longctx-8b",
+            name="LongCtx-8B",
+            parameter_count=8_000_000_000,
+            context_length=131072,
+            downloads=900,
+            likes=90,
+            gguf_variants=[
+                GGUFVariant(
+                    filename="long-Q4_K_M.gguf",
+                    quant_type="Q4_K_M",
+                    file_size_bytes=4_500_000_000,
+                ),
+            ],
+        ),
+        ModelInfo(
+            id="org/ShortCtx-8B",
+            family_id="shortctx-8b",
+            name="ShortCtx-8B",
+            parameter_count=8_000_000_000,
+            context_length=8192,
+            downloads=1000,
+            likes=100,
+            gguf_variants=[
+                GGUFVariant(
+                    filename="short-Q4_K_M.gguf",
+                    quant_type="Q4_K_M",
+                    file_size_bytes=4_500_000_000,
+                ),
+            ],
+        ),
+    ]
+    scores = {
+        "org/LongCtx-8B": 74.0,
+        "org/ShortCtx-8B": 76.0,
+    }
+    hw = _make_hardware(bandwidth_gbps=900.0)
+
+    results = rank_models(
+        models,
+        hw,
+        context_length=32768,
+        top_n=2,
+        benchmark_scores=scores,
+        require_direct_top=False,
+        task_profile="any",
+    )
+
+    assert len(results) == 2
+    assert results[0].model.family_id == "longctx-8b"
+    assert results[0].context_fits is True
+    assert results[1].context_fits is False


### PR DESCRIPTION
## Problem

`rank_models` ranks a model even when its declared max context (`model.context_length`) is below the requested `-c` / `--context-length`. At runtime that model is truncated or rejected, so the top recommendation can be unusable at the asked-for context.

## Fix

- Add a `context_fits` flag on `CompatibilityResult`, set in `check_compatibility`.
- When max context is known and too small, emit a warning and set `context_fits` to `False`.
- Apply a selection penalty in `_family_selection_key` so a model that cannot hold the requested context is demoted below one that can — without removing it.
- If nothing fits, the best available candidate is still returned, with a warning.

When `model.context_length` is unknown, `context_fits` stays `True` (no penalty).

## No behavior change at default context

At `-c 4096`, virtually all models have `context_length >= 4096`, so `context_fits` is `True` for everyone and ranking is unchanged. The penalty only engages when the requested context exceeds a model’s known declared max. The field defaults to `True`.

## Tests

- fit / no-fit / unknown `context_length`
- demotion ordering when two models have similar quality but only one supports the requested context