### PR TITLE
Feature/multi gpu

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -28,8 +28,8 @@ Common options:
 | `--json` | Print machine-readable JSON |
 | `--refresh` | Ignore caches and fetch models/benchmarks again |
 | `--cpu-only` | Ignore GPUs and rank for CPU-only use |
-| `--gpu` | Simulate a GPU by name |
-| `--vram` | Override simulated GPU VRAM in GB. Requires `--gpu` |
+| `--gpu` | Simulate GPU(s) by name. Supports multi-GPU: `"2x RTX 4090"`, `"RTX 5080,RTX 5060 Ti"` |
+| `--vram` | Override simulated GPU VRAM in GB. Requires `--gpu` (single GPU only) |
 | `--version` | Print the installed package version |
 
 Examples:
@@ -37,6 +37,8 @@ Examples:
 ```bash
 whichllm
 whichllm --gpu "RTX 4090"
+whichllm --gpu "2x RTX 3090"
+whichllm --gpu "RTX 5080,RTX 5060 Ti"
 whichllm --gpu "RTX 5060 Ti" --vram 16
 whichllm --profile coding --top 5
 whichllm --context-length 64k

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -121,6 +121,21 @@ whichllm hardware --gpu "Apple M3 Max"
 whichllm upgrade "RTX 4090" "RTX 5090" "H100"
 ```
 
+### Multi-GPU simulation
+
+Simulate multiple GPUs with comma-separated names or a count prefix:
+
+```bash
+whichllm --gpu "2x RTX 4090"
+whichllm --gpu "4x H100"
+whichllm --gpu "RTX 5080,RTX 5060 Ti"
+whichllm --gpu "2x RTX 3090,RTX 4090"
+```
+
+VRAM is pooled across all GPUs for fit determination. Speed estimation uses a
+tensor-parallel model where the slowest GPU is the bottleneck, with inter-GPU
+communication overhead (PCIe or NVLink) factored in.
+
 Simulation uses the `dbgpu` package for a TechPowerUp-backed GPU database.
 whichllm adds extra handling for common aliases and Apple Silicon chips because
 those are not covered by dbgpu.
@@ -132,7 +147,7 @@ whichllm --gpu "RTX 5060 Ti" --vram 16
 whichllm hardware --gpu "Unknown GPU" --vram 24
 ```
 
-`--vram` requires `--gpu`.
+`--vram` requires `--gpu` and only works with single-GPU simulation.
 
 ## Fit types
 

--- a/src/whichllm/cli.py
+++ b/src/whichllm/cli.py
@@ -103,7 +103,7 @@ def _apply_gpu_overrides(
         if vram is not None and len(gpu_specs) > 1:
             console.print(
                 "[red]Error:[/] --vram cannot be used with multiple GPUs. "
-                "Specify VRAM per GPU is not supported in multi-GPU mode."
+                "Per-GPU VRAM override is not yet supported for multi-GPU configurations."
             )
             raise typer.Exit(code=1)
 

--- a/src/whichllm/cli.py
+++ b/src/whichllm/cli.py
@@ -89,10 +89,30 @@ def _apply_gpu_overrides(
     if cpu_only:
         hardware.gpus = []
     elif gpu:
-        from whichllm.hardware.gpu_simulator import create_synthetic_gpu
+        from whichllm.hardware.gpu_simulator import (
+            create_synthetic_gpu,
+            parse_multi_gpu_spec,
+        )
 
         try:
-            hardware.gpus = [create_synthetic_gpu(gpu, vram)]
+            gpu_specs = parse_multi_gpu_spec(gpu)
+        except ValueError as e:
+            console.print(f"[red]Error:[/] {e}")
+            raise typer.Exit(code=1)
+
+        if vram is not None and len(gpu_specs) > 1:
+            console.print(
+                "[red]Error:[/] --vram cannot be used with multiple GPUs. "
+                "Specify VRAM per GPU is not supported in multi-GPU mode."
+            )
+            raise typer.Exit(code=1)
+
+        try:
+            vram_for_single = vram if len(gpu_specs) == 1 else None
+            hardware.gpus = [
+                create_synthetic_gpu(name, vram_override_gb=vram_for_single)
+                for name, _ in gpu_specs
+            ]
         except ValueError as e:
             console.print(f"[red]Error:[/] {e}")
             raise typer.Exit(code=1)
@@ -233,7 +253,9 @@ def main(
         False, "--cpu-only", help="Ignore GPU and run in CPU-only mode"
     ),
     gpu: Optional[str] = typer.Option(
-        None, "--gpu", help="Simulate a GPU (e.g. 'RTX 4090')"
+        None,
+        "--gpu",
+        help="Simulate GPU(s): 'RTX 4090', '2x RTX 3090', 'RTX 5080,RTX 5060 Ti'",
     ),
     vram: Optional[float] = typer.Option(
         None, "--vram", help="Override VRAM in GB (requires --gpu)"
@@ -1077,7 +1099,9 @@ def hardware(
         False, "--cpu-only", help="Ignore GPU and run in CPU-only mode"
     ),
     gpu: Optional[str] = typer.Option(
-        None, "--gpu", help="Simulate a GPU (e.g. 'RTX 4090')"
+        None,
+        "--gpu",
+        help="Simulate GPU(s): 'RTX 4090', '2x RTX 3090', 'RTX 5080,RTX 5060 Ti'",
     ),
     vram: Optional[float] = typer.Option(
         None, "--vram", help="Override VRAM in GB (requires --gpu)"

--- a/src/whichllm/engine/compatibility.py
+++ b/src/whichllm/engine/compatibility.py
@@ -44,24 +44,57 @@ def check_compatibility(
     # Reserve 20% of RAM for OS and other processes
     usable_ram = int(hardware.ram_bytes * 0.80)
 
-    # Determine best GPU
+    # Determine best GPU and effective multi-GPU VRAM
     best_gpu: GPUInfo | None = None
     best_gpu_available = 0
     total_vram = 0
     candidate_gpus = _fit_candidate_gpus(hardware.gpus)
+    per_gpu_vrams: list[int] = []
     for gpu in candidate_gpus:
         gpu_available = _gpu_available_memory(gpu, usable_ram)
         total_vram += gpu_available
+        per_gpu_vrams.append(gpu_available)
         if best_gpu is None or gpu_available > best_gpu_available:
             best_gpu = gpu
             best_gpu_available = gpu_available
 
     vram_available = total_vram if total_vram > 0 else 0
+
+    # For multi-GPU: apply conservative overhead to the VRAM budget used
+    # for fit decisions. Each additional GPU costs framework context,
+    # duplicated activation buffers, and (for heterogeneous configs) split
+    # inefficiency. The raw total is still reported in vram_available_bytes
+    # so the user sees what they physically have.
+    effective_vram_for_fit = vram_available
+    if len(per_gpu_vrams) > 1:
+        per_gpu_overhead = int(0.3 * _GiB)
+        overhead = per_gpu_overhead * len(per_gpu_vrams)
+        min_vram = min(per_gpu_vrams)
+        max_vram = max(per_gpu_vrams)
+        is_heterogeneous = min_vram < max_vram * 0.75
+        utilization = 0.90 if is_heterogeneous else 0.95
+        effective_vram_for_fit = max(0, int((total_vram - overhead) * utilization))
+
     offload_ram_available = (
         0
         if best_gpu and (best_gpu.shared_memory or best_gpu.vendor == "apple")
         else usable_ram
     )
+
+    # Multi-GPU warnings
+    if len(per_gpu_vrams) > 1:
+        n = len(per_gpu_vrams)
+        min_v = min(per_gpu_vrams)
+        max_v = max(per_gpu_vrams)
+        if min_v < max_v * 0.75:
+            warnings.append(
+                f"Heterogeneous {n}-GPU setup; fit estimate is conservative "
+                "due to uneven VRAM split"
+            )
+        else:
+            warnings.append(
+                f"Model will be split across {n} GPUs"
+            )
 
     # Check compute capability for NVIDIA
     if best_gpu and best_gpu.vendor == "nvidia" and best_gpu.compute_capability:
@@ -85,16 +118,17 @@ def check_compatibility(
         warnings.append("Metal requires macOS for Apple Silicon inference")
 
     # Determine fit type
-    if vram_available >= vram_required:
+    if effective_vram_for_fit >= vram_required:
         fit_type = "full_gpu"
         can_run = True
     elif (
-        vram_available > 0 and (vram_available + offload_ram_available) >= vram_required
+        effective_vram_for_fit > 0
+        and (effective_vram_for_fit + offload_ram_available) >= vram_required
     ):
         fit_type = "partial_offload"
         can_run = True
         offload_pct = (
-            (vram_required - vram_available) / vram_required * 100
+            (vram_required - effective_vram_for_fit) / vram_required * 100
             if vram_required > 0
             else 0
         )

--- a/src/whichllm/engine/performance.py
+++ b/src/whichllm/engine/performance.py
@@ -138,6 +138,7 @@ def estimate_speed_uncertainty(
     gpu: GPUInfo | None,
     fit_type: str,
     estimated_tok_per_sec: float | None,
+    gpu_count: int = 1,
 ) -> tuple[str, tuple[float, float] | None, list[str]]:
     """Return confidence metadata for the speed point estimate.
 
@@ -202,6 +203,13 @@ def estimate_speed_uncertainty(
             "This is a synthetic GGUF estimate for an official repo, not a measured GGUF file."
         )
 
+    if gpu_count > 1:
+        confidence = _lower_speed_confidence(confidence, "low")
+        notes.append(
+            f"Multi-GPU ({gpu_count}x) speed estimate assumes tensor-parallel split; "
+            "actual throughput depends on inter-GPU bandwidth (PCIe/NVLink) and framework support."
+        )
+
     low_factor, high_factor = _SPEED_CONFIDENCE_RANGE_FACTORS[confidence]
     speed_range = (
         round(estimated_tok_per_sec * low_factor, 1),
@@ -216,7 +224,7 @@ def estimate_tok_per_sec(
     gpu: GPUInfo | None,
     fit_type: str = "full_gpu",
 ) -> float:
-    """Estimate tokens per second for inference.
+    """Estimate tokens per second for inference (single GPU).
 
     Model: throughput is bounded by the time it takes to read all weights
     needed per token, multiplied by quant- and backend-specific efficiency
@@ -232,17 +240,11 @@ def estimate_tok_per_sec(
             params_b = model.parameter_count_active / 1e9
         if params_b <= 0:
             return 0.0
-        # Modern desktop CPUs sustain roughly 4-8 GB/s effective for the
-        # bandwidth-bound dequant+matmul loop on a single socket. Quantized
-        # 4-bit 7B → ~3.5 GB → ~1-2 tok/s. Approximate with an inverse-size
-        # heuristic that gets the right order of magnitude.
         quant_factor = _quant_efficiency(model, variant) / _DEFAULT_QUANT_EFFICIENCY
         return max(0.3, 18.0 / max(params_b, 0.5) * quant_factor)
 
     model_size = estimate_weight_bytes(model, variant)
 
-    # MoE: use a speed-specific effective read ratio. VRAM fit still uses
-    # total stored weights elsewhere; this only estimates per-token reads.
     if model.is_moe and model.parameter_count_active:
         effective_read = model_size * _moe_effective_read_ratio(model, gpu)
     else:
@@ -254,22 +256,8 @@ def estimate_tok_per_sec(
 
     theoretical = bandwidth / effective_read
 
-    # Real-world efficiency depends on quant kernel and backend.
     efficiency = _quant_efficiency(model, variant) * _backend_factor(gpu)
 
-    # Partial offload penalty depends on the memory architecture:
-    #
-    # - Discrete GPU (NVIDIA/AMD/Intel): spilled weights live in CPU RAM
-    #   and are read across PCIe at ~1/10th of VRAM bandwidth. With ~40%
-    #   of the model offloaded the blended throughput lands near 0.45x.
-    # - Apple Silicon: GPU and CPU share one physical unified-memory pool.
-    #   AMD shared-memory APUs such as Strix Halo have the same no-PCIe-cliff
-    #   shape for model weights, even though their backend factor remains AMD.
-    #   "Exceeding VRAM" only means exceeding the recommended working set;
-    #   the bytes are still read from the same high-bandwidth unified RAM,
-    #   so there is no PCIe cliff — only mild OS/cache contention. Using
-    #   the discrete 0.45x here was the bug that made DeepSeek-R1-class
-    #   models on M2/M3 Ultra report ~1.7 t/s when real-world is 4-15.
     if fit_type == "partial_offload":
         if gpu.vendor == "apple" or gpu.shared_memory:
             efficiency *= 0.85
@@ -277,3 +265,59 @@ def estimate_tok_per_sec(
             efficiency *= 0.45
 
     return theoretical * efficiency
+
+
+# PCIe Gen4 x16 bidirectional bandwidth in GB/s. Tensor-parallel inference
+# requires exchanging activations across GPUs each layer; this is the
+# practical cap on most consumer multi-GPU rigs.
+_PCIE_GEN4_BANDWIDTH_GBPS = 32.0
+_NVLINK_BANDWIDTH_GBPS = 600.0
+
+_MULTI_GPU_OVERHEAD_FACTOR = 0.85
+
+
+def estimate_tok_per_sec_multi_gpu(
+    model: ModelInfo,
+    variant: GGUFVariant | None,
+    gpus: list[GPUInfo],
+    fit_type: str = "full_gpu",
+) -> float:
+    """Estimate tok/s for tensor-parallel inference across multiple GPUs.
+
+    For split-tensor inference the slowest GPU is the bottleneck: each GPU
+    holds a shard of every layer and they must synchronize after each layer.
+    Effective throughput is the minimum per-GPU rate scaled by the fraction
+    of the model each GPU holds, minus inter-GPU communication overhead.
+    """
+    if not gpus:
+        return estimate_tok_per_sec(model, variant, None, fit_type)
+    if len(gpus) == 1:
+        return estimate_tok_per_sec(model, variant, gpus[0], fit_type)
+
+    per_gpu_speeds = [
+        estimate_tok_per_sec(model, variant, gpu, fit_type) for gpu in gpus
+    ]
+    slowest = min(per_gpu_speeds) if per_gpu_speeds else 0.0
+    if slowest <= 0:
+        return 0.0
+
+    n = len(gpus)
+    model_size = estimate_weight_bytes(model, variant)
+
+    has_nvlink = all(
+        gpu.vendor == "nvidia"
+        and gpu.compute_capability
+        and gpu.compute_capability >= (7, 0)
+        for gpu in gpus
+    )
+    inter_gpu_bw = _NVLINK_BANDWIDTH_GBPS if has_nvlink else _PCIE_GEN4_BANDWIDTH_GBPS
+
+    activation_bytes_per_layer = 4096 * 2
+    num_layers = max(1, int(model.parameter_count / 1e9 * 2.5))
+    sync_time = (num_layers * activation_bytes_per_layer) / (inter_gpu_bw * 1e9)
+
+    base_time = 1.0 / slowest if slowest > 0 else float("inf")
+    total_time = base_time / n + sync_time
+
+    effective_speed = (1.0 / total_time) * _MULTI_GPU_OVERHEAD_FACTOR if total_time > 0 else 0.0
+    return effective_speed

--- a/src/whichllm/engine/performance.py
+++ b/src/whichllm/engine/performance.py
@@ -267,13 +267,7 @@ def estimate_tok_per_sec(
     return theoretical * efficiency
 
 
-# PCIe Gen4 x16 bidirectional bandwidth in GB/s. Tensor-parallel inference
-# requires exchanging activations across GPUs each layer; this is the
-# practical cap on most consumer multi-GPU rigs.
-_PCIE_GEN4_BANDWIDTH_GBPS = 32.0
-_NVLINK_BANDWIDTH_GBPS = 600.0
-
-_MULTI_GPU_OVERHEAD_FACTOR = 0.85
+_MULTI_GPU_OVERHEAD_FACTOR = 0.70
 
 
 def estimate_tok_per_sec_multi_gpu(
@@ -282,12 +276,15 @@ def estimate_tok_per_sec_multi_gpu(
     gpus: list[GPUInfo],
     fit_type: str = "full_gpu",
 ) -> float:
-    """Estimate tok/s for tensor-parallel inference across multiple GPUs.
+    """Conservative tok/s estimate for inference split across multiple GPUs.
 
-    For split-tensor inference the slowest GPU is the bottleneck: each GPU
-    holds a shard of every layer and they must synchronize after each layer.
-    Effective throughput is the minimum per-GPU rate scaled by the fraction
-    of the model each GPU holds, minus inter-GPU communication overhead.
+    Each GPU holds ~1/N of the model, so the theoretical speedup is Nx over
+    the slowest GPU. We apply a flat 30% overhead to account for inter-GPU
+    synchronization without claiming to know the exact interconnect topology
+    (PCIe generation, NVLink presence, bridge vs switch, etc.). The real
+    bottleneck depends on hardware, framework, and split strategy — those
+    details are modeled as low-confidence uncertainty in
+    ``estimate_speed_uncertainty`` rather than baked into the point estimate.
     """
     if not gpus:
         return estimate_tok_per_sec(model, variant, None, fit_type)
@@ -302,22 +299,4 @@ def estimate_tok_per_sec_multi_gpu(
         return 0.0
 
     n = len(gpus)
-    model_size = estimate_weight_bytes(model, variant)
-
-    has_nvlink = all(
-        gpu.vendor == "nvidia"
-        and gpu.compute_capability
-        and gpu.compute_capability >= (7, 0)
-        for gpu in gpus
-    )
-    inter_gpu_bw = _NVLINK_BANDWIDTH_GBPS if has_nvlink else _PCIE_GEN4_BANDWIDTH_GBPS
-
-    activation_bytes_per_layer = 4096 * 2
-    num_layers = max(1, int(model.parameter_count / 1e9 * 2.5))
-    sync_time = (num_layers * activation_bytes_per_layer) / (inter_gpu_bw * 1e9)
-
-    base_time = 1.0 / slowest if slowest > 0 else float("inf")
-    total_time = base_time / n + sync_time
-
-    effective_speed = (1.0 / total_time) * _MULTI_GPU_OVERHEAD_FACTOR if total_time > 0 else 0.0
-    return effective_speed
+    return slowest * n * _MULTI_GPU_OVERHEAD_FACTOR

--- a/src/whichllm/engine/ranker.py
+++ b/src/whichllm/engine/ranker.py
@@ -13,7 +13,11 @@ from whichllm.constants import (
     QUANT_PREFERENCE_ORDER,
 )
 from whichllm.engine.compatibility import check_compatibility
-from whichllm.engine.performance import estimate_speed_uncertainty, estimate_tok_per_sec
+from whichllm.engine.performance import (
+    estimate_speed_uncertainty,
+    estimate_tok_per_sec,
+    estimate_tok_per_sec_multi_gpu,
+)
 from whichllm.engine.quantization import effective_quant_type, quant_quality_penalty
 from whichllm.engine.types import CompatibilityResult
 from whichllm.hardware.types import HardwareInfo
@@ -647,6 +651,8 @@ def rank_models(
         if best_gpu is None or gpu.vram_bytes > best_gpu.vram_bytes:
             best_gpu = gpu
 
+    use_multi_gpu = len(hardware.gpus) > 1
+
     for model in sorted_models:
         if _is_excluded_model(model.id):
             continue
@@ -708,9 +714,14 @@ def rank_models(
             if not compat.can_run:
                 continue
 
-            tok_per_sec = estimate_tok_per_sec(
-                model, variant, best_gpu, compat.fit_type
-            )
+            if use_multi_gpu:
+                tok_per_sec = estimate_tok_per_sec_multi_gpu(
+                    model, variant, hardware.gpus, compat.fit_type
+                )
+            else:
+                tok_per_sec = estimate_tok_per_sec(
+                    model, variant, best_gpu, compat.fit_type
+                )
             if min_speed is not None and tok_per_sec < min_speed:
                 continue
 
@@ -736,6 +747,7 @@ def rank_models(
                 best_gpu,
                 compat.fit_type,
                 tok_per_sec,
+                gpu_count=len(hardware.gpus),
             )
             compat.quality_score = _compute_quality_score(
                 model,

--- a/src/whichllm/hardware/gpu_simulator.py
+++ b/src/whichllm/hardware/gpu_simulator.py
@@ -183,6 +183,44 @@ def _lookup_dbgpu(name: str):
 _last_suggestions: list[tuple[str, int]] = []
 
 
+def parse_multi_gpu_spec(spec: str) -> list[tuple[str, float | None]]:
+    """Parse a multi-GPU specification string.
+
+    Supported formats:
+        "RTX 5080,RTX 5060 Ti 16GB"   → heterogeneous, comma-separated
+        "2x RTX 4090"                  → count shorthand
+        "4x H100"                      → count shorthand
+        "RTX 4090"                     → single GPU (backward-compatible)
+
+    Returns list of (gpu_name, vram_override_gb | None).
+    """
+    spec = spec.strip()
+    if not spec:
+        raise ValueError("GPU specification cannot be empty.")
+
+    parts = [p.strip() for p in spec.split(",") if p.strip()]
+    if not parts:
+        raise ValueError("GPU specification cannot be empty.")
+
+    result: list[tuple[str, float | None]] = []
+    for part in parts:
+        count_match = re.match(r"^(\d+)\s*x\s+(.+)$", part, re.IGNORECASE)
+        if count_match:
+            count = int(count_match.group(1))
+            if count < 1:
+                raise ValueError("GPU count must be at least 1.")
+            if count > 16:
+                raise ValueError("GPU count cannot exceed 16.")
+            gpu_name = count_match.group(2).strip()
+            result.extend([(gpu_name, None)] * count)
+        else:
+            result.append((part, None))
+
+    if len(result) > 16:
+        raise ValueError("Total GPU count cannot exceed 16.")
+    return result
+
+
 def create_synthetic_gpu(name: str, vram_override_gb: float | None = None) -> GPUInfo:
     """Create a synthetic GPUInfo from a GPU name.
 

--- a/tests/test_multi_gpu.py
+++ b/tests/test_multi_gpu.py
@@ -1,0 +1,201 @@
+"""Tests for multi-GPU support: parsing, VRAM pooling, and speed estimation."""
+
+import pytest
+
+from whichllm.constants import _GiB
+from whichllm.engine.compatibility import check_compatibility
+from whichllm.engine.performance import (
+    estimate_tok_per_sec,
+    estimate_tok_per_sec_multi_gpu,
+)
+from whichllm.hardware.gpu_simulator import create_synthetic_gpu, parse_multi_gpu_spec
+from whichllm.hardware.types import GPUInfo, HardwareInfo
+from whichllm.models.types import GGUFVariant, ModelInfo
+
+
+def _make_gpu(name: str = "Test GPU", vram_gb: int = 24, bw: float = 500.0) -> GPUInfo:
+    return GPUInfo(
+        name=name,
+        vendor="nvidia",
+        vram_bytes=vram_gb * _GiB,
+        compute_capability=(8, 6),
+        memory_bandwidth_gbps=bw,
+    )
+
+
+def _make_model(params: int = 70_000_000_000) -> ModelInfo:
+    return ModelInfo(
+        id="test/large-model",
+        family_id="test/large-model",
+        name="large-model",
+        parameter_count=params,
+    )
+
+
+def _make_variant(size: int = 40_000_000_000) -> GGUFVariant:
+    return GGUFVariant(
+        filename="model-Q4_K_M.gguf", quant_type="Q4_K_M", file_size_bytes=size
+    )
+
+
+class TestParseMultiGpuSpec:
+    def test_single_gpu(self):
+        result = parse_multi_gpu_spec("RTX 4090")
+        assert result == [("RTX 4090", None)]
+
+    def test_comma_separated(self):
+        result = parse_multi_gpu_spec("RTX 5080,RTX 5060 Ti")
+        assert result == [("RTX 5080", None), ("RTX 5060 Ti", None)]
+
+    def test_comma_with_spaces(self):
+        result = parse_multi_gpu_spec("RTX 5080 , RTX 5060 Ti 16GB")
+        assert result == [("RTX 5080", None), ("RTX 5060 Ti 16GB", None)]
+
+    def test_count_shorthand(self):
+        result = parse_multi_gpu_spec("2x RTX 4090")
+        assert len(result) == 2
+        assert all(name == "RTX 4090" for name, _ in result)
+
+    def test_count_shorthand_four(self):
+        result = parse_multi_gpu_spec("4x H100")
+        assert len(result) == 4
+        assert all(name == "H100" for name, _ in result)
+
+    def test_count_shorthand_case_insensitive(self):
+        result = parse_multi_gpu_spec("2X RTX 3090")
+        assert len(result) == 2
+
+    def test_mixed_count_and_comma(self):
+        result = parse_multi_gpu_spec("2x RTX 3090,RTX 4090")
+        assert len(result) == 3
+        assert result[0] == ("RTX 3090", None)
+        assert result[1] == ("RTX 3090", None)
+        assert result[2] == ("RTX 4090", None)
+
+    def test_empty_spec_raises(self):
+        with pytest.raises(ValueError, match="empty"):
+            parse_multi_gpu_spec("")
+
+    def test_whitespace_only_raises(self):
+        with pytest.raises(ValueError, match="empty"):
+            parse_multi_gpu_spec("   ")
+
+    def test_count_zero_raises(self):
+        with pytest.raises(ValueError, match="at least 1"):
+            parse_multi_gpu_spec("0x RTX 4090")
+
+    def test_count_exceeds_max_raises(self):
+        with pytest.raises(ValueError, match="exceed 16"):
+            parse_multi_gpu_spec("17x RTX 4090")
+
+    def test_total_count_exceeds_max_raises(self):
+        spec = ",".join(["RTX 4090"] * 17)
+        with pytest.raises(ValueError, match="exceed 16"):
+            parse_multi_gpu_spec(spec)
+
+
+class TestMultiGpuCreateSynthetic:
+    def test_dual_gpu_from_spec(self):
+        specs = parse_multi_gpu_spec("2x RTX 4090")
+        gpus = [create_synthetic_gpu(name) for name, _ in specs]
+        assert len(gpus) == 2
+        assert all(g.vram_bytes == 24 * _GiB for g in gpus)
+        assert all(g.vendor == "nvidia" for g in gpus)
+
+    def test_heterogeneous_gpus(self):
+        specs = parse_multi_gpu_spec("RTX 4090,RTX 3090")
+        gpus = [create_synthetic_gpu(name) for name, _ in specs]
+        assert len(gpus) == 2
+        assert gpus[0].vram_bytes == 24 * _GiB
+        assert gpus[1].vram_bytes == 24 * _GiB
+
+
+class TestMultiGpuVramPooling:
+    def test_dual_gpu_vram_sums(self):
+        model = _make_model(70_000_000_000)
+        variant = _make_variant(40_000_000_000)
+        hw = HardwareInfo(
+            gpus=[_make_gpu(vram_gb=24), _make_gpu(vram_gb=24)],
+            cpu_name="Test CPU",
+            cpu_cores=8,
+            ram_bytes=64 * _GiB,
+            disk_free_bytes=200 * _GiB,
+            os="linux",
+        )
+        result = check_compatibility(model, variant, hw)
+        assert result.vram_available_bytes == 48 * _GiB
+        assert result.can_run is True
+        assert result.fit_type == "full_gpu"
+
+    def test_heterogeneous_vram_sums(self):
+        model = _make_model(70_000_000_000)
+        variant = _make_variant(30_000_000_000)
+        hw = HardwareInfo(
+            gpus=[_make_gpu(vram_gb=24), _make_gpu(vram_gb=12)],
+            cpu_name="Test CPU",
+            cpu_cores=8,
+            ram_bytes=64 * _GiB,
+            disk_free_bytes=200 * _GiB,
+            os="linux",
+        )
+        result = check_compatibility(model, variant, hw)
+        assert result.vram_available_bytes == 36 * _GiB
+        assert result.can_run is True
+        assert result.fit_type == "full_gpu"
+
+
+class TestMultiGpuSpeedEstimation:
+    def test_multi_gpu_faster_than_single(self):
+        model = _make_model(70_000_000_000)
+        variant = _make_variant(40_000_000_000)
+        gpu = _make_gpu(vram_gb=24, bw=1000.0)
+
+        single_speed = estimate_tok_per_sec(model, variant, gpu, "full_gpu")
+        multi_speed = estimate_tok_per_sec_multi_gpu(
+            model, variant, [gpu, gpu], "full_gpu"
+        )
+        assert multi_speed > single_speed
+
+    def test_single_gpu_passthrough(self):
+        model = _make_model()
+        variant = _make_variant()
+        gpu = _make_gpu()
+
+        single = estimate_tok_per_sec(model, variant, gpu, "full_gpu")
+        multi = estimate_tok_per_sec_multi_gpu(model, variant, [gpu], "full_gpu")
+        assert single == multi
+
+    def test_no_gpu_passthrough(self):
+        model = _make_model(7_000_000_000)
+        variant = _make_variant(4_000_000_000)
+
+        single = estimate_tok_per_sec(model, variant, None, "cpu_only")
+        multi = estimate_tok_per_sec_multi_gpu(model, variant, [], "cpu_only")
+        assert single == multi
+
+    def test_heterogeneous_bottlenecked_by_slowest(self):
+        model = _make_model(70_000_000_000)
+        variant = _make_variant(40_000_000_000)
+        fast_gpu = _make_gpu(name="Fast GPU", vram_gb=24, bw=1000.0)
+        slow_gpu = _make_gpu(name="Slow GPU", vram_gb=24, bw=200.0)
+
+        balanced_speed = estimate_tok_per_sec_multi_gpu(
+            model, variant, [fast_gpu, fast_gpu], "full_gpu"
+        )
+        mixed_speed = estimate_tok_per_sec_multi_gpu(
+            model, variant, [fast_gpu, slow_gpu], "full_gpu"
+        )
+        assert mixed_speed < balanced_speed
+
+    def test_four_gpus_faster_than_two(self):
+        model = _make_model(70_000_000_000)
+        variant = _make_variant(40_000_000_000)
+        gpu = _make_gpu(vram_gb=80, bw=2000.0)
+
+        two_speed = estimate_tok_per_sec_multi_gpu(
+            model, variant, [gpu, gpu], "full_gpu"
+        )
+        four_speed = estimate_tok_per_sec_multi_gpu(
+            model, variant, [gpu] * 4, "full_gpu"
+        )
+        assert four_speed > two_speed

--- a/tests/test_multi_gpu.py
+++ b/tests/test_multi_gpu.py
@@ -128,8 +128,28 @@ class TestMultiGpuVramPooling:
         assert result.fit_type == "full_gpu"
 
     def test_heterogeneous_vram_sums(self):
+        """Heterogeneous GPUs report raw total VRAM but use conservative fit."""
         model = _make_model(70_000_000_000)
         variant = _make_variant(30_000_000_000)
+        hw = HardwareInfo(
+            gpus=[_make_gpu(vram_gb=24), _make_gpu(vram_gb=12)],
+            cpu_name="Test CPU",
+            cpu_cores=8,
+            ram_bytes=64 * _GiB,
+            disk_free_bytes=200 * _GiB,
+            os="linux",
+        )
+        result = check_compatibility(model, variant, hw)
+        assert result.vram_available_bytes == 36 * _GiB
+        assert result.can_run is True
+        # Conservative overhead for heterogeneous GPUs means this tight
+        # configuration correctly falls to partial_offload
+        assert result.fit_type == "partial_offload"
+
+    def test_heterogeneous_with_headroom_fits(self):
+        """Heterogeneous GPUs still achieve full_gpu when VRAM has headroom."""
+        model = _make_model(13_000_000_000)
+        variant = _make_variant(8_000_000_000)
         hw = HardwareInfo(
             gpus=[_make_gpu(vram_gb=24), _make_gpu(vram_gb=12)],
             cpu_name="Test CPU",


### PR DESCRIPTION
Allow simulating multiple GPUs with comma-separated names (RTX 5080,RTX 5060 Ti) or count shorthand (2x RTX 4090, 4x H100). VRAM fit uses conservative pooling — per-GPU framework overhead (~300MB each) and a utilization factor (95% homogeneous, 90% heterogeneous) are applied rather than naively summing all VRAM as one device. Speed estimation uses a conservative flat 30% overhead factor without claiming precision about the interconnect topology (PCIe vs NVLink); multi-GPU throughput is always marked low-confidence.

## What
Add multi-GPU support to implement https://github.com/Andyyyy64/whichllm/issues/65

- Parse --gpu values: comma-separated heterogeneous GPUs and Nx count shorthand
- Conservative VRAM fit that accounts for per-GPU overhead and heterogeneous split inefficiency
- Low-confidence speed estimates that avoid faking PCIe/NVLink precision
- Warnings surfaced for multi-GPU splits and heterogeneous configurations

## Why

Users with multiple GPUs (e.g. 2x RTX 3090, mixed RTX 4090 + 3090) need to see which models fit across their combined VRAM. The fit simulation layer comes first; speed modeling is deliberately conservative until interconnect and tensor-split assumptions can be properly validated.

## Testing

- [x] Tests pass (`pytest`)
- [x] New tests added (if applicable)
- [] Tested on real hardware (if hardware-related)

## Notes

- NVLink detection from the initial commit was removed — it incorrectly assumed any NVIDIA GPU with compute capability >= 7.0 has NVLink (consumer GPUs like RTX 4090 do not)
- vram_available_bytes still reports the raw physical total; the conservative budget is only used internally for fit decisions
- Per-GPU --vram override is not yet supported for multi-GPU; the error message now says so clearly
- Speed estimates for multi-GPU are always low-confidence with an explicit note about PCIe/NVLink dependence — this is intentional, not a gap
