### PR TITLE
fix: retry transient model fetch failures

### DIFF
--- a/src/whichllm/cli.py
+++ b/src/whichllm/cli.py
@@ -27,6 +27,23 @@ def _run_async(coro):
     return asyncio.run(coro)
 
 
+def _format_fetch_error(error: Exception) -> str:
+    """Return a useful one-line fetch error even when str(error) is empty."""
+    detail = str(error).strip()
+    if detail:
+        return detail
+
+    response = getattr(error, "response", None)
+    request = getattr(error, "request", None) or getattr(response, "request", None)
+    status_code = getattr(response, "status_code", None)
+    url = getattr(request, "url", None)
+    if status_code and url:
+        return f"{type(error).__name__}: HTTP {status_code} for {url}"
+    if url:
+        return f"{type(error).__name__} while requesting {url}"
+    return f"{type(error).__name__} with no detail from the network layer"
+
+
 def _print_version(value: bool) -> None:
     """Print version and exit when --version is requested."""
     if value:
@@ -293,7 +310,9 @@ def main(
                 save_cache(models_to_dicts(models))
                 progress.update(task, description=f"Fetched {len(models)} models")
             except Exception as e:
-                console.print(f"[red]Error fetching models:[/] {e}")
+                console.print(
+                    f"[red]Error fetching models:[/] {_format_fetch_error(e)}"
+                )
                 sys.exit(1)
 
         # Step 3: Fetch benchmark scores
@@ -424,7 +443,9 @@ def plan(
                 models = _run_async(fetch_models(include_vision=True))
                 save_cache(models_to_dicts(models))
             except Exception as e:
-                console.print(f"[red]Error fetching models:[/] {e}")
+                console.print(
+                    f"[red]Error fetching models:[/] {_format_fetch_error(e)}"
+                )
                 sys.exit(1)
 
     model = _search_model(models, model_name)
@@ -507,7 +528,9 @@ def upgrade(
                 models = _run_async(fetch_models(include_vision=False))
                 save_cache(models_to_dicts(models))
             except Exception as e:
-                console.print(f"[red]Error fetching models:[/] {e}")
+                console.print(
+                    f"[red]Error fetching models:[/] {_format_fetch_error(e)}"
+                )
                 raise typer.Exit(code=1)
 
         progress.update(task, description="Loading benchmark data...")
@@ -594,7 +617,7 @@ def _load_models(refresh: bool, include_vision: bool = True):
         save_cache(models_to_dicts(models))
         return models
     except Exception as e:
-        console.print(f"[red]Error fetching models:[/] {e}")
+        console.print(f"[red]Error fetching models:[/] {_format_fetch_error(e)}")
         sys.exit(1)
 
 

--- a/src/whichllm/models/benchmark_sources/aa_index.py
+++ b/src/whichllm/models/benchmark_sources/aa_index.py
@@ -21,6 +21,7 @@ import httpx
 from whichllm.models.benchmark_sources.constants import _NEXT_DATA_RE
 from whichllm.models.benchmark_sources.types import ExtractionFailed
 from whichllm.models.benchmark_sources.utils import _walk
+from whichllm.models.http import get_with_retries
 
 logger = logging.getLogger(__name__)
 
@@ -230,7 +231,7 @@ async def fetch_aa_index_scores(client: httpx.AsyncClient) -> dict[str, float]:
     Raises on HTTP / parse failure.
     """
     scores: dict[str, float] = {}
-    resp = await client.get(AA_LEADERBOARD_URL)
+    resp = await get_with_retries(client, AA_LEADERBOARD_URL)
     resp.raise_for_status()
     match = _NEXT_DATA_RE.search(resp.text)
     if not match:

--- a/src/whichllm/models/benchmark_sources/aider.py
+++ b/src/whichllm/models/benchmark_sources/aider.py
@@ -17,6 +17,8 @@ import re
 
 import httpx
 
+from whichllm.models.http import get_with_retries
+
 logger = logging.getLogger(__name__)
 
 AIDER_POLYGLOT_YML_URL = (
@@ -108,7 +110,7 @@ def _parse_yaml_lite(text: str) -> list[tuple[str, float]]:
 async def fetch_aider_polyglot_scores(client: httpx.AsyncClient) -> dict[str, float]:
     """Fetch Aider polyglot pass-rates. Raises on HTTP / parse failure."""
     scores: dict[str, float] = {}
-    resp = await client.get(AIDER_POLYGLOT_YML_URL)
+    resp = await get_with_retries(client, AIDER_POLYGLOT_YML_URL)
     resp.raise_for_status()
     pairs = _parse_yaml_lite(resp.text)
     if not pairs:

--- a/src/whichllm/models/benchmark_sources/chatbot_arena.py
+++ b/src/whichllm/models/benchmark_sources/chatbot_arena.py
@@ -4,6 +4,8 @@ import re
 
 import httpx
 
+from whichllm.models.http import get_with_retries
+
 # --- Data source URLs ---
 ARENA_ROWS_URL = "https://datasets-server.huggingface.co/rows"
 ARENA_DATASET = "mathewhe/chatbot-arena-elo"
@@ -94,7 +96,8 @@ async def fetch_arena_scores(client: httpx.AsyncClient) -> dict[str, float]:
     offset = 0
 
     while True:
-        resp = await client.get(
+        resp = await get_with_retries(
+            client,
             ARENA_ROWS_URL,
             params={
                 "dataset": ARENA_DATASET,

--- a/src/whichllm/models/benchmark_sources/open_llm_leaderboard.py
+++ b/src/whichllm/models/benchmark_sources/open_llm_leaderboard.py
@@ -4,6 +4,8 @@ import io
 
 import httpx
 
+from whichllm.models.http import get_with_retries
+
 LEADERBOARD_PARQUET_URL = (
     "https://huggingface.co/api/datasets/open-llm-leaderboard/contents"
     "/parquet/default/train/0.parquet"
@@ -24,7 +26,9 @@ async def _fetch_leaderboard_parquet(client: httpx.AsyncClient) -> dict[str, flo
     """Download Open LLM Leaderboard parquet (requires pyarrow)."""
     import pyarrow.parquet as pq
 
-    resp = await client.get(LEADERBOARD_PARQUET_URL, follow_redirects=True)
+    resp = await get_with_retries(
+        client, LEADERBOARD_PARQUET_URL, follow_redirects=True
+    )
     resp.raise_for_status()
     table = pq.read_table(
         io.BytesIO(resp.content),
@@ -46,7 +50,8 @@ async def _fetch_leaderboard_api(client: httpx.AsyncClient) -> dict[str, float]:
     offset = 0
 
     while True:
-        resp = await client.get(
+        resp = await get_with_retries(
+            client,
             LEADERBOARD_ROWS_URL,
             params={
                 "dataset": LEADERBOARD_DATASET,

--- a/src/whichllm/models/fetcher.py
+++ b/src/whichllm/models/fetcher.py
@@ -10,6 +10,7 @@ import statistics
 import httpx
 
 from whichllm.constants import QUANT_BYTES_PER_WEIGHT
+from whichllm.models.http import get_with_retries
 from whichllm.models.types import GGUFVariant, ModelInfo
 
 logger = logging.getLogger(__name__)
@@ -593,7 +594,7 @@ async def fetch_models(
             ],
         }
         logger.debug(f"Fetching models from HF API (limit={limit})")
-        resp = await client.get(f"{HF_API_BASE}/models", params=params)
+        resp = await get_with_retries(client, f"{HF_API_BASE}/models", params=params)
         resp.raise_for_status()
         data_list = resp.json()
         for data in data_list:
@@ -617,7 +618,9 @@ async def fetch_models(
             ],
         }
         logger.debug("Fetching GGUF models from HF API")
-        resp = await client.get(f"{HF_API_BASE}/models", params=gguf_params)
+        resp = await get_with_retries(
+            client, f"{HF_API_BASE}/models", params=gguf_params
+        )
         resp.raise_for_status()
         gguf_data_list = resp.json()
 
@@ -645,7 +648,9 @@ async def fetch_models(
             ],
         }
         logger.debug("Fetching recent GGUF models from HF API")
-        resp = await client.get(f"{HF_API_BASE}/models", params=recent_params)
+        resp = await get_with_retries(
+            client, f"{HF_API_BASE}/models", params=recent_params
+        )
         resp.raise_for_status()
         recent_data_list = resp.json()
 
@@ -679,7 +684,9 @@ async def fetch_models(
                 f"Fetching trending {filter_value or 'all'} models from HF API"
             )
             try:
-                resp = await client.get(f"{HF_API_BASE}/models", params=trending_params)
+                resp = await get_with_retries(
+                    client, f"{HF_API_BASE}/models", params=trending_params
+                )
                 resp.raise_for_status()
                 trending_data_list = resp.json()
             except (httpx.HTTPError, ValueError) as e:
@@ -775,7 +782,8 @@ async def fetch_models(
             if model_id in seen_ids:
                 continue
             try:
-                resp = await client.get(
+                resp = await get_with_retries(
+                    client,
                     f"{HF_API_BASE}/models/{model_id}",
                     params={
                         "expand[]": [
@@ -823,7 +831,9 @@ async def fetch_models(
                     ],
                 }
                 logger.debug(f"Fetching {pipeline_tag} models from HF API")
-                resp = await client.get(f"{HF_API_BASE}/models", params=mm_params)
+                resp = await get_with_retries(
+                    client, f"{HF_API_BASE}/models", params=mm_params
+                )
                 resp.raise_for_status()
                 mm_data_list = resp.json()
 

--- a/src/whichllm/models/http.py
+++ b/src/whichllm/models/http.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import asyncio
+import random
+
+import httpx
+
+RETRYABLE_STATUS_CODES = {408, 429, 500, 502, 503, 504}
+
+
+async def get_with_retries(
+    client: httpx.AsyncClient,
+    url: str,
+    *,
+    attempts: int = 3,
+    base_delay: float = 0.25,
+    max_delay: float = 2.0,
+    jitter: float = 0.1,
+    retry_status_codes: set[int] | None = None,
+    **kwargs,
+) -> httpx.Response:
+    """GET with bounded retry/backoff for transient HTTP failures."""
+    retry_codes = retry_status_codes or RETRYABLE_STATUS_CODES
+    last_attempt = max(1, attempts) - 1
+
+    for attempt in range(last_attempt + 1):
+        try:
+            response = await client.get(url, **kwargs)
+        except (httpx.TimeoutException, httpx.TransportError):
+            if attempt >= last_attempt:
+                raise
+        else:
+            if response.status_code not in retry_codes or attempt >= last_attempt:
+                return response
+
+        delay = min(max_delay, base_delay * (2**attempt))
+        if jitter > 0:
+            delay += random.uniform(0, jitter)
+        if delay > 0:
+            await asyncio.sleep(delay)
+
+    raise RuntimeError("unreachable retry state")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Tests for CLI helper logic."""
 
+import httpx
 import pytest
 from typer import Exit
 
@@ -7,6 +8,7 @@ import whichllm.cli as cli_mod
 from whichllm.cli import (
     _auto_min_params_for_profile,
     _fill_missing_published_at,
+    _format_fetch_error,
     _generate_chat_script,
     _include_vision_candidates,
     _merge_model_eval_benchmarks,
@@ -98,6 +100,26 @@ def test_version_option_prints_version_and_exits():
     assert _current_version() in result.stdout
 
 
+def test_format_fetch_error_uses_exception_class_when_message_is_empty():
+    class EmptyNetworkError(Exception):
+        def __str__(self) -> str:
+            return ""
+
+    assert _format_fetch_error(EmptyNetworkError()) == (
+        "EmptyNetworkError with no detail from the network layer"
+    )
+
+
+def test_format_fetch_error_includes_status_and_url_for_empty_http_error():
+    request = httpx.Request("GET", "https://huggingface.co/api/models")
+    response = httpx.Response(429, request=request)
+    error = httpx.HTTPStatusError("", request=request, response=response)
+
+    assert _format_fetch_error(error) == (
+        "HTTPStatusError: HTTP 429 for https://huggingface.co/api/models"
+    )
+
+
 def test_merge_model_eval_benchmarks_is_now_a_noop():
     """As of the self_reported evidence tier, _merge_model_eval_benchmarks
     must NOT mutate the leaderboard scores. Uploader-reported hf_eval values
@@ -153,7 +175,8 @@ def test_resolve_evidence_mode_direct_alias_wins():
 # --------------- plan command tests ---------------
 
 
-def test_plan_no_model_found_shows_error():
+def test_plan_no_model_found_shows_error(monkeypatch):
+    monkeypatch.setattr("whichllm.models.cache.load_cache", lambda: [])
     runner = CliRunner()
     result = runner.invoke(app, ["plan", "nonexistent_model_xyz_999"])
     assert result.exit_code != 0
@@ -579,7 +602,8 @@ def test_run_auto_pick_resolves_ranked_gguf_before_launch(monkeypatch):
     assert "transformers" not in captured["cmd"]
 
 
-def test_snippet_no_model_found():
+def test_snippet_no_model_found(monkeypatch):
+    monkeypatch.setattr(cli_mod, "_load_models", lambda refresh: [])
     runner = CliRunner()
     result = runner.invoke(app, ["snippet", "nonexistent_model_xyz_999"])
     assert result.exit_code != 0

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,0 +1,63 @@
+import asyncio
+
+import httpx
+import pytest
+
+from whichllm.models.benchmark_sources.chatbot_arena import fetch_arena_scores
+from whichllm.models.http import get_with_retries
+
+
+def test_get_with_retries_retries_429_then_returns_response(monkeypatch):
+    calls = 0
+    sleeps: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls < 3:
+            return httpx.Response(429, request=request)
+        return httpx.Response(200, json={"ok": True}, request=request)
+
+    async def run() -> httpx.Response:
+        monkeypatch.setattr("whichllm.models.http.asyncio.sleep", fake_sleep)
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(transport=transport) as client:
+            return await get_with_retries(
+                client,
+                "https://example.test/models",
+                base_delay=0.01,
+                jitter=0,
+            )
+
+    response = asyncio.run(run())
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert calls == 3
+    assert sleeps == [0.01, 0.02]
+
+
+def test_benchmark_source_retries_429_before_final_failure(monkeypatch):
+    calls = 0
+
+    async def fake_sleep(delay: float) -> None:
+        return None
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(429, request=request)
+
+    async def run() -> None:
+        monkeypatch.setattr("whichllm.models.http.asyncio.sleep", fake_sleep)
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(transport=transport) as client:
+            with pytest.raises(httpx.HTTPStatusError):
+                await fetch_arena_scores(client)
+
+    asyncio.run(run())
+
+    assert calls == 3


### PR DESCRIPTION
## Summary

- Add bounded retry/backoff with jitter for retryable HTTP fetches.
- Use the retry path for Hugging Face model fetches and benchmark sources.
- Make the Error fetching models output include useful detail even when the underlying network exception has an empty message.

Fixes #88.
Addresses #85.

## QA

- uv run pytest: 228 passed
- uvx ruff check .: passed
- uvx ruff format --check .: passed
- uv run whichllm --status --top 3 --json: succeeds locally