### PR TITLE
Add Apple M5-family simulation support

### DIFF
--- a/src/whichllm/data/gpu.py
+++ b/src/whichllm/data/gpu.py
@@ -133,7 +133,9 @@ GPU_BANDWIDTH: dict[str, float] = {
     "M4 Max": 546.0,
     "M4 Pro": 273.0,
     "M4": 120.0,
+    "M5 Max": 614.0,
     "M5 Pro": 307.0,
+    "M5": 153.0,
 }
 
 # NVIDIA GPU compute capability lookup (substring match, case-insensitive)

--- a/src/whichllm/data/gpu.py
+++ b/src/whichllm/data/gpu.py
@@ -133,6 +133,7 @@ GPU_BANDWIDTH: dict[str, float] = {
     "M4 Max": 546.0,
     "M4 Pro": 273.0,
     "M4": 120.0,
+    "M5 Pro": 307.0,
 }
 
 # NVIDIA GPU compute capability lookup (substring match, case-insensitive)

--- a/src/whichllm/hardware/gpu_simulator.py
+++ b/src/whichllm/hardware/gpu_simulator.py
@@ -61,7 +61,9 @@ _APPLE_SILICON_CHIPS: dict[str, tuple[str, float]] = {
     "M4 Pro": ("Apple M4 Pro", 24.0),
     "M4 Max": ("Apple M4 Max", 36.0),
     "M4 Ultra": ("Apple M4 Ultra", 64.0),
+    "M5": ("Apple M5", 16.0),
     "M5 Pro": ("Apple M5 Pro", 24.0),
+    "M5 Max": ("Apple M5 Max", 36.0),
 }
 
 

--- a/src/whichllm/hardware/gpu_simulator.py
+++ b/src/whichllm/hardware/gpu_simulator.py
@@ -61,6 +61,7 @@ _APPLE_SILICON_CHIPS: dict[str, tuple[str, float]] = {
     "M4 Pro": ("Apple M4 Pro", 24.0),
     "M4 Max": ("Apple M4 Max", 36.0),
     "M4 Ultra": ("Apple M4 Ultra", 64.0),
+    "M5 Pro": ("Apple M5 Pro", 24.0),
 }
 
 


### PR DESCRIPTION
Summary: Add Apple M5, M5 Pro, and M5 Max unified-memory bandwidth lookups and simulator entries. Values use Apple-published memory bandwidths: M5 153 GB/s, M5 Pro 307 GB/s, and M5 Max 614 GB/s. Default simulated unified memory follows base MacBook Pro configurations: 16 GB, 24 GB, and 36 GB. Tests: .venv/bin/pytest tests/test_gpu_simulator.py