### PR TITLE
Fix GGUF benchmark lookup without base_model

### DIFF
--- a/src/whichllm/models/benchmark.py
+++ b/src/whichllm/models/benchmark.py
@@ -427,6 +427,47 @@ def _generate_candidates(model_id: str) -> list[str]:
     return candidates
 
 
+def _append_unique(candidates: list[str], candidate: str) -> None:
+    if candidate and candidate not in candidates:
+        candidates.append(candidate)
+
+
+def _strip_repo_suffix(model_id: str) -> str:
+    for suffix in _REPO_SUFFIXES:
+        if model_id.endswith(suffix):
+            return model_id[: -len(suffix)]
+    return model_id
+
+
+def _generate_score_name_candidates(
+    model_id: str, scores: dict[str, float]
+) -> list[str]:
+    """Match community repo names to benchmark IDs with the same model name."""
+    stripped = _strip_repo_suffix(model_id)
+    repo_name = stripped.rsplit("/", 1)[-1]
+    model_names = [repo_name]
+
+    explicit_candidates: list[str] = []
+    if "_" in repo_name:
+        org, name = repo_name.split("_", 1)
+        if org and name:
+            _append_unique(explicit_candidates, f"{org}/{name}")
+            _append_unique(model_names, name)
+
+    score_candidates: list[str] = []
+    wanted_names = {name.lower() for name in model_names if name}
+    for score_id in scores:
+        score_name = score_id.rsplit("/", 1)[-1].lower()
+        if score_name in wanted_names:
+            _append_unique(score_candidates, score_id)
+
+    return explicit_candidates + [
+        candidate
+        for candidate in score_candidates
+        if candidate not in explicit_candidates
+    ]
+
+
 def lookup_benchmark(
     model_id: str,
     base_model: str | None,
@@ -501,7 +542,10 @@ def lookup_benchmark_evidence(
         return BenchmarkEvidence(score=direct_result, confidence=1.0, source="direct")
 
     # Try model_id-derived variants (inherited)
-    for candidate in _generate_candidates(model_id)[1:]:
+    variant_candidates = _generate_candidates(model_id)[1:]
+    for candidate in _generate_score_name_candidates(model_id, scores):
+        _append_unique(variant_candidates, candidate)
+    for candidate in variant_candidates:
         result = _try_lookup(candidate, scores, ci_index)
         if result is not None:
             if not _params_compatible(actual_params_b, candidate):

--- a/tests/test_benchmark_lookup.py
+++ b/tests/test_benchmark_lookup.py
@@ -47,6 +47,71 @@ def test_lookup_benchmark_gguf_suffix_match_is_inherited():
     assert result == (70.0, False)
 
 
+def test_lookup_benchmark_community_gguf_without_base_model_matches_official_id():
+    scores = {"Qwen/Qwen3.6-27B": 83.5}
+    ci, line = build_score_index(scores)
+    buckets = build_line_bucket_index(scores)
+    result = lookup_benchmark_evidence(
+        "unsloth/Qwen3.6-27B-GGUF",
+        None,
+        scores,
+        ci,
+        line,
+        buckets,
+    )
+    assert result.source == "variant"
+    assert result.score == 83.5
+
+
+def test_lookup_benchmark_community_gguf_underscore_name_matches_official_id():
+    scores = {"Qwen/Qwen3.6-35B-A3B": 86.0}
+    ci, line = build_score_index(scores)
+    buckets = build_line_bucket_index(scores)
+    result = lookup_benchmark_evidence(
+        "unsloth/Qwen_Qwen3.6-35B-A3B-GGUF",
+        None,
+        scores,
+        ci,
+        line,
+        buckets,
+    )
+    assert result.source == "variant"
+    assert result.score == 86.0
+
+
+def test_lookup_benchmark_community_gguf_keeps_params_guard():
+    scores = {"Qwen/Qwen3.6-27B": 83.5}
+    ci, line = build_score_index(scores)
+    buckets = build_line_bucket_index(scores)
+    result = lookup_benchmark_evidence(
+        "unsloth/Qwen3.6-27B-GGUF",
+        None,
+        scores,
+        ci,
+        line,
+        buckets,
+        actual_params_b=6.6,
+    )
+    assert result.source != "variant"
+
+
+def test_lookup_benchmark_community_gguf_beats_self_reported_score():
+    scores = {"Qwen/Qwen3.6-27B": 83.5}
+    ci, line = build_score_index(scores)
+    buckets = build_line_bucket_index(scores)
+    result = lookup_benchmark_evidence(
+        "unsloth/Qwen3.6-27B-GGUF",
+        None,
+        scores,
+        ci,
+        line,
+        buckets,
+        self_reported_score=12.0,
+    )
+    assert result.source == "variant"
+    assert result.score == 83.5
+
+
 def test_lookup_benchmark_evidence_direct_has_full_confidence():
     scores = {"Qwen/Qwen2.5-7B-Instruct": 70.0}
     ci, line = build_score_index(scores)


### PR DESCRIPTION
## Summary
- match community GGUF repo names to benchmark IDs with the same model name when `cardData.base_model` is missing
- support underscore repo names such as `Qwen_Qwen3.6-35B-A3B-GGUF`
- keep parameter compatibility checks on inherited variant matches

Fixes #89.

## Tests
- `uv run pytest tests/test_benchmark_lookup.py`

## Notes
- `uv run pytest` was run locally on Windows: 231 passed, 1 existing platform-specific failure in `tests/test_utils.py::test_cache_dir_respects_xdg_cache_home` where `_cache_dir()` ignores `XDG_CACHE_HOME` on Windows.