### PR TITLE
fix: restore AA live fetch after RSC migration (#87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- AA name matching now canonicalizes variant-suffixed display names
+  (`(Reasoning)`, `(Non-reasoning)`, `(high)`) so live fetch maps ~46 models
+  instead of ~8.
+- RSC chunk regex now matches any tag number (`[\d+, ...]`) instead of only
+  tag 1, so model data in other RSC segments is no longer silently dropped.
+
 ## [0.5.8] - 2026-06-05
 
 ### Added

--- a/src/whichllm/models/benchmark_sources/aa_index.py
+++ b/src/whichllm/models/benchmark_sources/aa_index.py
@@ -93,6 +93,19 @@ AA_NAME_TO_HF_IDS: dict[str, list[str]] = {
 # normalized, and 8B-class (Qwen3-8B = 30) → 40 normalized. This keeps a
 # strong 8B model competitive with frozen-OLLB 7B scores while still leaving
 # clear headroom for frontier-tier models.
+_PAREN_RE = re.compile(r"\([^)]*\)")
+
+
+def _canonical_name(name: str) -> str:
+    name = _PAREN_RE.sub("", name)
+    name = name.lower().replace("-", " ").replace("_", " ")
+    return re.sub(r"\s+", " ", name).strip()
+
+
+_AA_CANON_TO_HF_IDS: dict[str, list[str]] = {}
+for _disp, _ids in AA_NAME_TO_HF_IDS.items():
+    _AA_CANON_TO_HF_IDS.setdefault(_canonical_name(_disp), []).extend(_ids)
+
 _AA_INDEX_MIN = 12.5
 _AA_INDEX_MAX = 56.2
 
@@ -295,7 +308,9 @@ async def fetch_aa_index_scores(client: httpx.AsyncClient) -> dict[str, float]:
         if current is None or score > current:
             best_by_name[name] = score
     for name, score in best_by_name.items():
-        hf_ids = AA_NAME_TO_HF_IDS.get(name)
+        hf_ids = AA_NAME_TO_HF_IDS.get(name) or _AA_CANON_TO_HF_IDS.get(
+            _canonical_name(name)
+        )
         if not hf_ids:
             continue
         normalized = _normalize_aa_index(score)

--- a/src/whichllm/models/benchmark_sources/aa_index.py
+++ b/src/whichllm/models/benchmark_sources/aa_index.py
@@ -15,10 +15,11 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 
 import httpx
 
-from whichllm.models.benchmark_sources.constants import _NEXT_DATA_RE
+from whichllm.models.benchmark_sources.constants import _NEXT_DATA_RE, _RSC_PUSH_RE
 from whichllm.models.benchmark_sources.types import ExtractionFailed
 from whichllm.models.benchmark_sources.utils import _walk
 from whichllm.models.http import get_with_retries
@@ -193,6 +194,49 @@ def _normalize_aa_index(index: float) -> float:
     return max(0.0, min(100.0, round(normalized, 1)))
 
 
+_MODELS_ARRAY_RE = re.compile(r'"models"\s*:\s*\[')
+
+
+def _extract_rsc_pairs(html: str) -> list[tuple[str, float]]:
+    """Extract (display_name, intelligenceIndex) pairs from RSC push payloads.
+
+    The Next.js App Router embeds server data via ``self.__next_f.push([1, "..."])``
+    calls instead of the old ``__NEXT_DATA__`` script tag.  We concatenate and
+    unescape the RSC chunks, locate every ``"models":[...]`` JSON array, and
+    parse each model object for ``name`` + ``intelligenceIndex``.
+    """
+    chunks = _RSC_PUSH_RE.findall(html)
+    if not chunks:
+        return []
+    stream = "".join(chunks)
+    stream = stream.replace('\\"', '"').replace("\\\\", "\\")
+    pairs: list[tuple[str, float]] = []
+    for m in _MODELS_ARRAY_RE.finditer(stream):
+        arr_start = stream.index("[", m.start())
+        depth = 0
+        arr_end = arr_start
+        for i, c in enumerate(stream[arr_start:]):
+            if c == "[":
+                depth += 1
+            elif c == "]":
+                depth -= 1
+            if depth == 0:
+                arr_end = arr_start + i + 1
+                break
+        try:
+            models = json.loads(stream[arr_start:arr_end])
+        except (json.JSONDecodeError, ValueError):
+            continue
+        for obj in models:
+            if not isinstance(obj, dict):
+                continue
+            name = obj.get("name")
+            score = obj.get("intelligenceIndex")
+            if isinstance(name, str) and isinstance(score, (int, float)) and score > 0:
+                pairs.append((name.strip(), float(score)))
+    return pairs
+
+
 def _extract_aa_pairs(payload: dict) -> list[tuple[str, float]]:
     """Walk the Next.js payload looking for {name, intelligenceIndex}-shaped
     objects regardless of where they are nested."""
@@ -233,11 +277,13 @@ async def fetch_aa_index_scores(client: httpx.AsyncClient) -> dict[str, float]:
     scores: dict[str, float] = {}
     resp = await get_with_retries(client, AA_LEADERBOARD_URL)
     resp.raise_for_status()
-    match = _NEXT_DATA_RE.search(resp.text)
-    if not match:
-        raise ExtractionFailed("__NEXT_DATA__ payload not found")
-    payload = json.loads(match.group("json"))
-    pairs = _extract_aa_pairs(payload)
+    pairs = _extract_rsc_pairs(resp.text)
+    if not pairs:
+        match = _NEXT_DATA_RE.search(resp.text)
+        if not match:
+            raise ExtractionFailed("neither RSC push payloads nor __NEXT_DATA__ found")
+        payload = json.loads(match.group("json"))
+        pairs = _extract_aa_pairs(payload)
     if not pairs:
         raise ExtractionFailed("AA leaderboard: no (name, score) pairs found")
     # When the same display name appears multiple times (different size

--- a/src/whichllm/models/benchmark_sources/constants.py
+++ b/src/whichllm/models/benchmark_sources/constants.py
@@ -6,4 +6,4 @@ _NEXT_DATA_RE = re.compile(
     r'<script id="__NEXT_DATA__"[^>]*>(?P<json>.*?)</script>', re.DOTALL
 )
 
-_RSC_PUSH_RE = re.compile(r'self\.__next_f\.push\(\[1,"(.*?)"\]\)', re.DOTALL)
+_RSC_PUSH_RE = re.compile(r'self\.__next_f\.push\(\[\d+,"(.*?)"\]\)', re.DOTALL)

--- a/src/whichllm/models/benchmark_sources/constants.py
+++ b/src/whichllm/models/benchmark_sources/constants.py
@@ -5,3 +5,5 @@ import re
 _NEXT_DATA_RE = re.compile(
     r'<script id="__NEXT_DATA__"[^>]*>(?P<json>.*?)</script>', re.DOTALL
 )
+
+_RSC_PUSH_RE = re.compile(r'self\.__next_f\.push\(\[1,"(.*?)"\]\)', re.DOTALL)

--- a/tests/test_aa_index.py
+++ b/tests/test_aa_index.py
@@ -7,6 +7,7 @@ import httpx
 import pytest
 
 from whichllm.models.benchmark_sources.aa_index import (
+    _canonical_name,
     _extract_rsc_pairs,
     fetch_aa_index_scores,
     get_aa_curated_fallback,
@@ -95,3 +96,60 @@ def test_fallback_returns_normalized_scores():
     assert len(fallback) > 0
     for hf_id, score in fallback.items():
         assert 0.0 < score <= 100.0, f"{hf_id} score {score} out of range"
+
+
+def test_canonical_name_strips_variants():
+    assert _canonical_name("Qwen3 14B (Reasoning)") == "qwen3 14b"
+    assert _canonical_name("GLM-5 (Non-reasoning)") == "glm 5"
+    assert _canonical_name("gpt-oss-20B (high)") == "gpt oss 20b"
+
+
+def test_canonical_name_normalizes_separators():
+    assert _canonical_name("GLM-4.7-Flash") == "glm 4.7 flash"
+    assert _canonical_name("DeepSeek_V3") == "deepseek v3"
+    assert _canonical_name("Kimi  K2") == "kimi k2"
+
+
+def test_canonical_name_preserves_distinct_models():
+    assert _canonical_name("GLM-5") != _canonical_name("GLM-5.1")
+    assert _canonical_name("Qwen3 14B") != _canonical_name("Qwen3 8B")
+    assert _canonical_name("DeepSeek V3") != _canonical_name("DeepSeek V3.1")
+
+
+def test_canonical_fallback_maps_parenthetical_variant():
+    html = _make_rsc_html(
+        ("Qwen3 14B (Reasoning)", "qwen3-14b-reasoning", 35.0),
+    )
+    pairs = _extract_rsc_pairs(html)
+    assert len(pairs) > 0
+    scores = {name: score for name, score in pairs}
+    assert scores["Qwen3 14B (Reasoning)"] == 35.0
+
+    mock_resp = AsyncMock(spec=httpx.Response)
+    mock_resp.text = html
+    mock_resp.raise_for_status = lambda: None
+    client = AsyncMock(spec=httpx.AsyncClient)
+
+    async def run():
+        with patch(
+            "whichllm.models.benchmark_sources.aa_index.get_with_retries",
+            return_value=mock_resp,
+        ):
+            return await fetch_aa_index_scores(client)
+
+    result = asyncio.run(run())
+    assert "Qwen/Qwen3-14B" in result
+
+
+def test_rsc_non_tag1_chunks_extracted():
+    """Chunks with tag != 1 should also be scanned for model data."""
+    objs = (
+        '{\\"name\\":\\"DeepSeek V3\\",'
+        '\\"slug\\":\\"deepseek-v3\\",'
+        '\\"intelligenceIndex\\":38.0}'
+    )
+    models = f'{{\\"models\\":[{objs}]}}'
+    html = f'<html><script>self.__next_f.push([3,"{models}"])</script></html>'
+    pairs = _extract_rsc_pairs(html)
+    assert len(pairs) == 1
+    assert pairs[0] == ("DeepSeek V3", 38.0)

--- a/tests/test_aa_index.py
+++ b/tests/test_aa_index.py
@@ -1,0 +1,97 @@
+"""Tests for Artificial Analysis Intelligence Index extraction."""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from whichllm.models.benchmark_sources.aa_index import (
+    _extract_rsc_pairs,
+    fetch_aa_index_scores,
+    get_aa_curated_fallback,
+)
+from whichllm.models.benchmark_sources.types import ExtractionFailed
+
+
+def _make_rsc_html(*entries: tuple[str, str, float | None]) -> str:
+    """Build minimal HTML with RSC push payloads wrapping a ``"models"`` array."""
+    objs = []
+    for name, slug, score in entries:
+        score_val = "null" if score is None else str(score)
+        objs.append(
+            f'{{\\"name\\":\\"{name}\\",'
+            f'\\"slug\\":\\"{slug}\\",'
+            f'\\"intelligenceIndex\\":{score_val}}}'
+        )
+    deprecated_obj = (
+        '{\\"name\\":\\"Old Model\\",'
+        '\\"slug\\":\\"old-model\\",'
+        '\\"deprecated\\":true,'
+        '\\"intelligenceIndex\\":15.0}'
+    )
+    all_objs = ",".join([*objs, deprecated_obj])
+    models = f'{{\\"models\\":[{all_objs}]}}'
+    return f'<html><script>self.__next_f.push([1,"{models}"])</script></html>'
+
+
+def test_rsc_format_extracts_scores():
+    html = _make_rsc_html(
+        ("Kimi K2", "kimi-k2", 47.0),
+        ("DeepSeek V3", "deepseek-v3", 38.0),
+    )
+    pairs = _extract_rsc_pairs(html)
+    names = {name for name, _ in pairs}
+    assert "Kimi K2" in names
+    assert "DeepSeek V3" in names
+    scores = {name: score for name, score in pairs}
+    assert scores["Kimi K2"] == 47.0
+    assert scores["DeepSeek V3"] == 38.0
+
+
+def test_rsc_no_pushes_returns_empty():
+    html = "<html><body>nothing here</body></html>"
+    assert _extract_rsc_pairs(html) == []
+
+
+def test_deprecated_models_included():
+    html = _make_rsc_html(("Active Model", "active", 40.0))
+    pairs = _extract_rsc_pairs(html)
+    names = {name for name, _ in pairs}
+    assert "Old Model" in names
+
+
+def test_null_score_not_borrowed_from_next_model():
+    html = _make_rsc_html(
+        ("Null Model", "null-model", None),
+        ("Real Model", "real-model", 42.0),
+    )
+    pairs = _extract_rsc_pairs(html)
+    scores = {name: score for name, score in pairs}
+    assert "Null Model" not in scores
+    assert scores["Real Model"] == 42.0
+
+
+def test_missing_both_formats_raises():
+    mock_resp = AsyncMock(spec=httpx.Response)
+    mock_resp.text = "<html><body>no data</body></html>"
+    mock_resp.raise_for_status = lambda: None
+
+    client = AsyncMock(spec=httpx.AsyncClient)
+
+    async def run():
+        with patch(
+            "whichllm.models.benchmark_sources.aa_index.get_with_retries",
+            return_value=mock_resp,
+        ):
+            await fetch_aa_index_scores(client)
+
+    with pytest.raises(ExtractionFailed, match="neither RSC.*nor __NEXT_DATA__"):
+        asyncio.run(run())
+
+
+def test_fallback_returns_normalized_scores():
+    fallback = get_aa_curated_fallback()
+    assert len(fallback) > 0
+    for hf_id, score in fallback.items():
+        assert 0.0 < score <= 100.0, f"{hf_id} score {score} out of range"


### PR DESCRIPTION
Fixes #87

## Approach

AA's RSC push payloads contain `"models":[...]` arrays that are valid JSON after unescaping. We parse those directly instead of regex-matching individual fields — avoids field-order brittleness and a cross-boundary bug where null `intelligenceIndex` models steal the next model's score.

RSC → `__NEXT_DATA__` fallback → `ExtractionFailed` → curated fallback.

## Changes

- `constants.py` — add `_RSC_PUSH_RE` for RSC push chunks
- `aa_index.py` — add `_extract_rsc_pairs()` using JSON parsing; try RSC first in `fetch_aa_index_scores()`
- `tests/test_aa_index.py` — 6 tests

## Tests

- RSC extraction returns correct (name, score) pairs
- Graceful empty on non-RSC HTML
- Deprecated models included
- Null `intelligenceIndex` doesn't steal next model's score
- `ExtractionFailed` when neither format found
- Curated fallback returns valid 0–100 scores
- Live: 491 entries extracted, 0 false matches against JSON ground truth