### PR TITLE
Add MXFP4 and NVFP4 quantization support

### DIFF
--- a/src/whichllm/data/quantization.py
+++ b/src/whichllm/data/quantization.py
@@ -20,6 +20,14 @@ QUANT_BYTES_PER_WEIGHT: dict[str, float] = {
     "IQ4_XS": 0.5,
     "IQ3_XXS": 0.375,
     "IQ2_XXS": 0.25,
+    # 4-bit microscaling float formats (OCP MXFP4 / NVIDIA NVFP4).
+    # MXFP4: E2M1 element + one E8M0 (8-bit) scale per block of 32 weights
+    #   -> (4*32 + 8) / 32 = 4.25 bits/weight = 0.53125 bytes.
+    # NVFP4: E2M1 element + one E4M3 (8-bit) scale per block of 16 weights
+    #   (plus a negligible per-tensor FP32 scale) -> (4*16 + 8) / 16 = 4.5 bits
+    #   = 0.5625 bytes, the same footprint as Q4_K_M.
+    "MXFP4": 0.53125,
+    "NVFP4": 0.5625,
     # Sub-2-bit / ternary tiers (extremely lossy)
     "Q1_0": 0.28,
     "Q2_0": 0.28,
@@ -50,6 +58,12 @@ QUANT_QUALITY_PENALTY: dict[str, float] = {
     "Q4_K_M": 0.05,
     "Q4_K_S": 0.055,
     "Q4_0": 0.06,
+    # NVFP4's finer per-16 E4M3 scale recovers more accuracy than MXFP4's
+    # coarser per-32 E8M0 (power-of-two) scale, so NVFP4 sits on par with the
+    # mature 4-bit quantizers (Q4_K_M / AWQ at 0.05) while MXFP4 is slightly
+    # lossier.
+    "NVFP4": 0.05,
+    "MXFP4": 0.06,
     "Q3_K_M": 0.08,
     "Q3_K_S": 0.12,
     "Q3_K_L": 0.075,
@@ -77,6 +91,8 @@ QUANT_QUALITY_PENALTY: dict[str, float] = {
 QUANT_PREFERENCE_ORDER = [
     "Q4_K_M",
     "Q4_K_S",
+    "NVFP4",
+    "MXFP4",
     "Q5_K_M",
     "Q5_K_S",
     "Q6_K",

--- a/src/whichllm/engine/performance.py
+++ b/src/whichllm/engine/performance.py
@@ -25,6 +25,11 @@ _QUANT_EFFICIENCY: dict[str, float] = {
     "Q4_K_M": 0.55,
     "Q4_K_S": 0.55,
     "Q4_0": 0.53,
+    # 4-bit microscaling floats decode through native FP4 tensor-core paths
+    # (e.g. Blackwell) where weight reads dominate, so they land in the same
+    # high-efficiency band as the best 4-bit GGUF kernels.
+    "NVFP4": 0.56,
+    "MXFP4": 0.55,
     "Q3_K_M": 0.50,
     "Q3_K_S": 0.48,
     "Q3_K_L": 0.50,

--- a/src/whichllm/engine/quantization.py
+++ b/src/whichllm/engine/quantization.py
@@ -11,6 +11,10 @@ from whichllm.models.types import GGUFVariant, ModelInfo
 _NON_GGUF_PATTERNS: list[tuple[str, str]] = [
     (r"(^|[-_/])awq($|[-_/])", "AWQ"),
     (r"(^|[-_/])gptq($|[-_/])", "GPTQ"),
+    # 4-bit microscaling float formats. Anchored so they only match a distinct
+    # repo-name token, never a substring of an unrelated id.
+    (r"(^|[-_/])mxfp4($|[-_/])", "MXFP4"),
+    (r"(^|[-_/])nvfp4($|[-_/])", "NVFP4"),
     (r"(bnb[-_/]?4bit|nf4|int4|4bit)", "BNB_4BIT"),
     (r"(int8|8bit)", "INT8"),
     (r"(^|[-_/])fp8($|[-_/])", "FP8"),
@@ -23,6 +27,8 @@ _NON_GGUF_BYTES_PER_WEIGHT: dict[str, float] = {
     "AWQ": 0.5,
     "GPTQ": 0.5,
     "BNB_4BIT": 0.5,
+    "MXFP4": 0.53125,
+    "NVFP4": 0.5625,
     "INT8": 1.0,
     "FP8": 1.0,
     "BF16": 2.0,
@@ -34,6 +40,8 @@ _NON_GGUF_QUALITY_PENALTY: dict[str, float] = {
     "AWQ": 0.05,
     "GPTQ": 0.05,
     "BNB_4BIT": 0.07,
+    "MXFP4": 0.06,
+    "NVFP4": 0.05,
     "INT8": 0.02,
     "FP8": 0.02,
     "BF16": 0.0,

--- a/src/whichllm/engine/ranker.py
+++ b/src/whichllm/engine/ranker.py
@@ -101,7 +101,7 @@ _SOURCE_WEIGHTS: dict[str, float] = {
 
 _SYNTHETIC_QUANTS = ("Q3_K_M", "Q4_K_M", "Q5_K_M", "Q6_K", "Q8_0")
 _PREQUANTIZED_REPO_RE = re.compile(
-    r"-(awq|gptq|bnb|fp8|fp16|bf16|nvfp4|int4|int8|4bit|8bit|gguf)$",
+    r"-(awq|gptq|bnb|fp8|fp16|bf16|mxfp4|nvfp4|int4|int8|4bit|8bit|gguf)$",
     re.IGNORECASE,
 )
 

--- a/src/whichllm/models/benchmark.py
+++ b/src/whichllm/models/benchmark.py
@@ -289,7 +289,7 @@ def _extract_model_lines(model_id: str) -> list[str]:
     lower = model_id.lower()
 
     # Pre-strip repo/quant suffixes and date codes before line extraction
-    stripped = re.sub(r"-(gguf|awq|gptq|fp8|fp16|bf16|nvfp4)$", "", lower)
+    stripped = re.sub(r"-(gguf|awq|gptq|fp8|fp16|bf16|mxfp4|nvfp4)$", "", lower)
     stripped = re.sub(r"-\d{4}(-hf)?$", "", stripped)  # date suffixes like -2507
 
     lines: list[str] = []

--- a/src/whichllm/models/fetcher.py
+++ b/src/whichllm/models/fetcher.py
@@ -220,6 +220,7 @@ def _extract_quant_type(filename: str) -> str:
         r"[.-](Q\d+_\d+)",
         r"[.-](Q\d+_K)",
         r"[.-](IQ\d+_\w+)",
+        r"[.-](MXFP4|NVFP4)",
         r"[.-](F16|FP16|BF16|F32)",
     ]
     upper = filename.upper()

--- a/src/whichllm/models/grouper.py
+++ b/src/whichllm/models/grouper.py
@@ -27,6 +27,7 @@ def _normalize_name(model_id: str) -> str:
         r"-fp8$",
         r"-fp16$",
         r"-bf16$",
+        r"-mxfp4$",
         r"-nvfp4$",
         r"-\d+bit$",
         r"-\d{4}$",  # date suffixes like -2507, -2503

--- a/tests/test_grouper.py
+++ b/tests/test_grouper.py
@@ -1,6 +1,6 @@
 """Tests for model grouping logic."""
 
-from whichllm.models.grouper import group_models
+from whichllm.models.grouper import _normalize_name, group_models
 from whichllm.models.types import ModelInfo
 
 
@@ -32,6 +32,14 @@ def test_group_by_name_normalization():
     gguf = _make_model("org/model-v1-GGUF", downloads=200)
     families = group_models([base, gguf])
     assert len(families) <= 2  # may or may not merge depending on normalization
+
+
+def test_fp4_suffixes_normalize_to_base_family():
+    # MXFP4 and NVFP4 derivatives must collapse onto the base family the same
+    # way the older quant suffixes do, instead of orphaning into their own.
+    base = _normalize_name("openai/gpt-oss-20b")
+    assert _normalize_name("openai/gpt-oss-20b-MXFP4") == base
+    assert _normalize_name("openai/gpt-oss-20b-NVFP4") == base
 
 
 def test_ungrouped_models_separate():

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -35,3 +35,43 @@ def test_awq_vram_is_lower_than_fp16_fallback():
     assert estimate_vram(awq, None, context_length=4096) < estimate_vram(
         fp16, None, context_length=4096
     )
+
+
+def test_infer_mxfp4():
+    model = _make_model("openai/gpt-oss-20b-MXFP4")
+    assert infer_non_gguf_quant_type(model.id) == "MXFP4"
+    assert effective_quant_type(model, None) == "MXFP4"
+
+
+def test_infer_nvfp4():
+    model = _make_model("nvidia/Llama-3.1-8B-Instruct-NVFP4")
+    assert infer_non_gguf_quant_type(model.id) == "NVFP4"
+    assert effective_quant_type(model, None) == "NVFP4"
+
+
+def test_fp4_patterns_do_not_false_match_plain_ids():
+    # A bare id with no fp4 token must not be mislabeled as a microscaling float.
+    plain = _make_model("meta-llama/Llama-3.1-8B-Instruct")
+    assert infer_non_gguf_quant_type(plain.id) == "FP16"
+
+
+def test_estimate_weight_bytes_for_fp4_formats():
+    mxfp4 = _make_model("openai/gpt-oss-20b-MXFP4", params=20_000_000_000)
+    nvfp4 = _make_model("nvidia/model-NVFP4", params=20_000_000_000)
+    assert estimate_weight_bytes(mxfp4, None) == int(20_000_000_000 * 0.53125)
+    assert estimate_weight_bytes(nvfp4, None) == int(20_000_000_000 * 0.5625)
+
+
+def test_fp4_vram_is_lower_than_fp16_fallback():
+    mxfp4 = _make_model("openai/gpt-oss-20b-MXFP4")
+    fp16 = _make_model("openai/gpt-oss-20b")
+    assert estimate_vram(mxfp4, None, context_length=4096) < estimate_vram(
+        fp16, None, context_length=4096
+    )
+
+
+def test_extract_quant_type_parses_fp4_gguf_filenames():
+    from whichllm.models.fetcher import _extract_quant_type
+
+    assert _extract_quant_type("gpt-oss-20b-MXFP4.gguf") == "MXFP4"
+    assert _extract_quant_type("model.NVFP4.gguf") == "NVFP4"

--- a/tests/test_ranker.py
+++ b/tests/test_ranker.py
@@ -1,5 +1,6 @@
 """Tests for ranking behavior."""
 
+from whichllm.engine.quantization import effective_quant_type
 from whichllm.engine.ranker import rank_models
 from whichllm.hardware.types import GPUInfo, HardwareInfo
 from whichllm.models.types import GGUFVariant, ModelInfo
@@ -86,6 +87,45 @@ def test_quant_filter_applies_to_non_gguf_models():
 
     assert len(awq_only) == 1
     assert q4_only == []
+
+
+def test_quant_filter_matches_mxfp4_non_gguf_model():
+    model = ModelInfo(
+        id="openai/gpt-oss-20b-MXFP4",
+        family_id="gpt-oss-20b",
+        name="gpt-oss-20b-MXFP4",
+        parameter_count=20_000_000_000,
+        downloads=1000,
+        likes=100,
+    )
+    # Linux + NVIDIA: non-GGUF formats are runnable, so the filter resolves.
+    hw = _make_hardware(vram_gb=24, bandwidth_gbps=900.0)
+
+    mxfp4_only = rank_models([model], hw, top_n=5, quant_filter="MXFP4")
+    nvfp4_only = rank_models([model], hw, top_n=5, quant_filter="NVFP4")
+
+    assert len(mxfp4_only) == 1
+    # The label surfaced in the output table (display.py uses the same call).
+    assert (
+        effective_quant_type(mxfp4_only[0].model, mxfp4_only[0].gguf_variant) == "MXFP4"
+    )
+    assert nvfp4_only == []
+
+
+def test_darwin_backend_filters_out_fp4_non_gguf_models():
+    mxfp4_model = ModelInfo(
+        id="openai/gpt-oss-20b-MXFP4",
+        family_id="gpt-oss-20b",
+        name="gpt-oss-20b-MXFP4",
+        parameter_count=20_000_000_000,
+        downloads=1000,
+        likes=100,
+    )
+    hw = _make_hardware(
+        vram_gb=64, bandwidth_gbps=400.0, vendor="apple", os_name="darwin"
+    )
+    results = rank_models([mxfp4_model], hw, top_n=10)
+    assert results == []
 
 
 def test_darwin_backend_filters_out_non_gguf_models():


### PR DESCRIPTION
Closes #27.

## What

Adds first-class support for the two 4-bit *microscaling float* quantization formats that recent local-LLM and hardware paths have started shipping:

- **MXFP4** — OCP Microscaling FP4 (E2M1 element + one E8M0 8-bit scale per block of 32), used by e.g. the GPT-OSS releases.
- **NVFP4** — NVIDIA FP4 (E2M1 element + one E4M3 8-bit scale per block of 16, plus a negligible per-tensor FP32 scale), targeting Blackwell-class hardware.

## Why

NVFP4 was already half-wired: it appeared in the family-normalization, benchmark pre-strip, and prequantized-repo regexes, **but was missing from the quantization tables**. The net effect was a latent bug — an `…-NVFP4` repo fell through `infer_non_gguf_quant_type` to the `FP16` default, so it was **labeled `FP16` in the output and its VRAM was overestimated ~3.5×** (2.0 vs 0.5625 bytes/weight). MXFP4 was not recognized anywhere, so `--quant MXFP4` returned no candidates and MXFP4 repos were orphaned from their base family during grouping.

This PR makes both formats consistent across every path that already knew about the older quant formats.

## Changes

| Area | File | Change |
|------|------|--------|
| Bytes-per-weight | `data/quantization.py`, `engine/quantization.py` | MXFP4 `0.53125` (4.25 bits), NVFP4 `0.5625` (4.5 bits) |
| Quality penalty | `data/quantization.py`, `engine/quantization.py` | NVFP4 `0.05` (par with Q4_K_M — finer per-16 E4M3 scale), MXFP4 `0.06` (coarser per-32 E8M0 power-of-two scale) |
| Speed efficiency | `engine/performance.py` | NVFP4 `0.56`, MXFP4 `0.55` (native FP4 tensor-core paths are weight-read-bound) |
| Preference order | `data/quantization.py` | inserted in the 4-bit tier |
| ID parsing | `engine/quantization.py` | anchored `(^\|[-_/])mxfp4($\|[-_/])` / `nvfp4` patterns |
| GGUF filename parsing | `models/fetcher.py` | `_extract_quant_type` recognizes `*.MXFP4.gguf` / `*.NVFP4.gguf` |
| Family grouping | `models/grouper.py` | strip `-mxfp4` / `-nvfp4` suffixes |
| Benchmark pre-strip | `models/benchmark.py` | add `mxfp4` to the suffix alternation (nvfp4 already present) |

Output labeling needs no change — `display.py` already derives the label from `effective_quant_type`, which now returns the correct format.

## Bytes-per-weight derivation

- MXFP4: `(4·32 + 8) / 32 = 4.25 bits = 0.53125 B/w`
- NVFP4: `(4·16 + 8) / 16 = 4.5 bits = 0.5625 B/w` (per-tensor FP32 scale amortizes to ~0)

## Tests

Covers the issue's "Done when" list:
- parsing from model IDs (`test_infer_mxfp4`, `test_infer_nvfp4`) and from GGUF filenames (`test_extract_quant_type_parses_fp4_gguf_filenames`)
- a negative case confirming the anchored patterns don't false-match plain IDs
- weight-byte and VRAM estimation for both formats
- `--quant MXFP4` returning a candidate on a runnable (Linux+NVIDIA) host and being correctly filtered out on a GGUF-only backend
- family grouping collapsing `…-MXFP4` / `…-NVFP4` onto the base family
- the output label assertion uses the same `effective_quant_type` call as `display.py`

Full suite: `301 passed`; `ruff check .` and `ruff format --check .` clean.
