### PR TITLE
feat: resolve detected GPU bandwidth via dbgpu fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- GPU bandwidth detection no longer depends solely on the hand-curated
+  catalog. When a detected card is missing from `GPU_BANDWIDTH`, bandwidth is
+  now resolved from the bundled TechPowerUp database (dbgpu, 2824 GPUs) using
+  strict name matching only: an exact normalized hit or a name plus VRAM-size
+  bin, never fuzzy. Laptop / Mobile / Max-Q names can no longer inherit a
+  desktop card's bandwidth, and VRAM bins written without a space
+  (`RTX A2000 12GB`) are recognized. This fixes the cluster of reports where
+  an uncatalogued GPU showed `BW: N/A`, was estimated at `0.0 tok/s`, and
+  received oversized recommendations (#74, #98).
 - Artificial Analysis Intelligence Index is fetched live again. The
   artificialanalysis.ai leaderboard migrated to the Next.js App Router and no
   longer ships a `__NEXT_DATA__` blob, so every run logged

--- a/src/whichllm/hardware/amd.py
+++ b/src/whichllm/hardware/amd.py
@@ -8,7 +8,8 @@ import shlex
 import subprocess
 from pathlib import Path
 
-from whichllm.constants import AMD_SHARED_MEMORY_APU_MARKERS, GPU_BANDWIDTH, _GiB
+from whichllm.constants import AMD_SHARED_MEMORY_APU_MARKERS, _GiB
+from whichllm.hardware.gpu_db import _static_bandwidth, resolve_detected_bandwidth
 from whichllm.hardware.types import GPUInfo
 
 logger = logging.getLogger(__name__)
@@ -19,38 +20,12 @@ _DISPLAY_CLASSES = (
     "display controller",
 )
 
-_SORTED_BW_KEYS = sorted(GPU_BANDWIDTH, key=len, reverse=True)
-
 
 def _lookup_bandwidth(name: str) -> float | None:
-    name_upper = name.upper()
-    # For non-compound names, direct substring match is safe.
-    if "/" not in name:
-        for key in _SORTED_BW_KEYS:
-            if key.upper() in name_upper:
-                return GPU_BANDWIDTH[key]
-        return None
-    # Compound lspci names like "Navi 22 [Radeon RX 6700/6700 XT/6750 XT / 6800M/6850M XT]"
-    # contain multiple variants separated by '/'. Split and try each segment,
-    # re-applying the "RX " prefix for bare segments like "6750 XT".
-    import re
-
-    bracket = re.search(r"\[(.+)]", name)
-    raw = bracket.group(1) if bracket else name
-    for seg in raw.split("/"):
-        seg = seg.strip()
-        if not seg:
-            continue
-        seg_upper = seg.upper()
-        for key in _SORTED_BW_KEYS:
-            if key.upper() in seg_upper:
-                return GPU_BANDWIDTH[key]
-        # Bare segment like "6750 XT" — try with "RX " prefix
-        prefixed_upper = f"RX {seg}".upper()
-        for key in _SORTED_BW_KEYS:
-            if key.upper() in prefixed_upper:
-                return GPU_BANDWIDTH[key]
-    return None
+    """Curated GPU_BANDWIDTH lookup, compound-lspci aware. Kept for regression
+    tests; live detection goes through ``resolve_detected_bandwidth``, which
+    also consults dbgpu."""
+    return _static_bandwidth(name)
 
 
 def _is_shared_memory_apu(name: str) -> bool:
@@ -76,7 +51,7 @@ def _make_gpu(
         vendor="amd",
         vram_bytes=_normalize_apu_vram(name, vram_bytes),
         rocm_version=rocm_version,
-        memory_bandwidth_gbps=_lookup_bandwidth(name),
+        memory_bandwidth_gbps=resolve_detected_bandwidth(name, vram_bytes),
         shared_memory=shared_memory,
     )
 

--- a/src/whichllm/hardware/gpu_db.py
+++ b/src/whichllm/hardware/gpu_db.py
@@ -1,0 +1,176 @@
+"""Resolve GPU memory bandwidth for *detected* hardware.
+
+Detection passes the raw driver name (e.g. ``"NVIDIA GeForce RTX 5090 Laptop
+GPU"``). Unlike ``--gpu`` simulation, where the user typed the name and a fuzzy
+guess plus a ``(simulated)`` label is acceptable, a wrong match on real
+hardware is worse than no data: giving a laptop card its desktop bandwidth
+produces confidently wrong speed estimates and oversized recommendations
+(issues #74, #61, #93).
+
+So this resolver is deliberately strict:
+
+* The hand-curated ``GPU_BANDWIDTH`` table stays authoritative and is tried
+  first, so existing behaviour for known cards is unchanged.
+* The curated lookup is mobile-aware: a laptop/Max-Q driver name will not match
+  a desktop key (``"RTX 5090"`` no longer swallows ``"RTX 5090 Laptop GPU"``).
+* dbgpu is only consulted to fill gaps, and only via an exact normalised-name
+  hit or a name plus a VRAM-size suffix (``"RTX 4060 Ti 16 GB"``). It never
+  falls back to fuzzy matching, so a variant qualifier (Ti / SUPER / Mobile /
+  Max-Q / XT) can never be silently dropped onto the wrong card.
+* ``"Laptop GPU"`` in a driver name is normalised to dbgpu's ``"Mobile"``.
+
+The change is purely additive: cards already covered by ``GPU_BANDWIDTH`` keep
+their exact value, and cards that previously resolved to ``None`` now get a
+correct bandwidth whenever dbgpu can identify them safely.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import re
+
+from whichllm.constants import GPU_BANDWIDTH, _GiB
+
+logger = logging.getLogger(__name__)
+
+_TRADEMARK_RE = re.compile(r"\((?:tm|r)\)", re.IGNORECASE)
+_VENDOR_WORD_RE = re.compile(r"\b(?:nvidia|amd|ati|intel|corporation)\b", re.IGNORECASE)
+_LAPTOP_GPU_RE = re.compile(r"\blaptop gpu\b", re.IGNORECASE)
+_TRAILING_GRAPHICS_RE = re.compile(r"\bgraphics\s*$", re.IGNORECASE)
+_WHITESPACE_RE = re.compile(r"\s+")
+_MOBILE_MARKER_RE = re.compile(r"\b(?:laptop|mobile|max-?q)\b", re.IGNORECASE)
+# Driver names write VRAM bins without a space ("RTX A2000 12GB"); dbgpu
+# writes "RTX A2000 12 GB" (#98).
+_VRAM_NOSPACE_RE = re.compile(r"\b(\d+)GB\b", re.IGNORECASE)
+_BRACKET_RE = re.compile(r"\[(.+)]")
+# A dbgpu name may extend a matched query with a VRAM-size bin only
+# ("RTX 4060 Ti 16 GB"). A variant word (Mobile, Ti, D, ...) is never benign.
+_VRAM_SUFFIX_RE = re.compile(r"^\s+\d+\s*gb\b", re.IGNORECASE)
+_VRAM_GB_RE = re.compile(r"(\d+)\s*gb", re.IGNORECASE)
+
+
+def _normalize_detected_name(name: str) -> str:
+    """Reduce a raw driver name toward dbgpu's naming convention."""
+    text = _TRADEMARK_RE.sub("", name)
+    text = _VENDOR_WORD_RE.sub("", text)
+    text = _LAPTOP_GPU_RE.sub("Mobile", text)
+    text = _TRAILING_GRAPHICS_RE.sub("", text)
+    text = _VRAM_NOSPACE_RE.sub(r"\1 GB", text)
+    return _WHITESPACE_RE.sub(" ", text).strip()
+
+
+def _substring_bandwidth(name: str) -> float | None:
+    """Curated ``GPU_BANDWIDTH`` lookup (longest key first), mobile-aware.
+
+    When the detected name is a laptop/Max-Q card, a desktop key is not allowed
+    to match it via substring, since the two have very different bandwidth.
+    """
+    if not name:
+        return None
+    name_upper = name.upper()
+    name_is_mobile = bool(_MOBILE_MARKER_RE.search(name))
+    for key in sorted(GPU_BANDWIDTH, key=len, reverse=True):
+        if key.upper() in name_upper:
+            if name_is_mobile and not _MOBILE_MARKER_RE.search(key):
+                continue
+            return GPU_BANDWIDTH[key]
+    return None
+
+
+def _static_bandwidth(name: str) -> float | None:
+    """Curated lookup that also handles compound lspci names.
+
+    Compound names like ``"Navi 22 [Radeon RX 6700/6700 XT/6750 XT /
+    6800M/6850M XT]"`` list several variants; the first segment that resolves
+    wins, with a ``"RX "`` prefix retry for bare segments like ``"6750 XT"``.
+    dbgpu is never consulted for these: the name does not identify a single
+    card, so the curated value for the listed family is the safest answer.
+    """
+    if not name:
+        return None
+    if "/" not in name:
+        return _substring_bandwidth(name)
+    bracket = _BRACKET_RE.search(name)
+    raw = bracket.group(1) if bracket else name
+    for seg in raw.split("/"):
+        seg = seg.strip()
+        if not seg:
+            continue
+        bandwidth = _substring_bandwidth(seg) or _substring_bandwidth(f"RX {seg}")
+        if bandwidth is not None:
+            return bandwidth
+    return None
+
+
+def _vram_gb(canonical_name: str) -> int | None:
+    match = _VRAM_GB_RE.search(canonical_name)
+    return int(match.group(1)) if match else None
+
+
+@functools.lru_cache(maxsize=1)
+def _dbgpu_index() -> tuple[object | None, dict[str, str] | None]:
+    """Build ``{normalized_name: canonical_dbgpu_name}``.
+
+    Returns ``(db, index)`` or ``(None, None)`` if dbgpu is unavailable, so the
+    resolver degrades to static-only instead of raising.
+    """
+    try:
+        from dbgpu import GPUDatabase
+
+        db = GPUDatabase.default()
+    except Exception as exc:  # pragma: no cover - dbgpu is a hard dependency
+        logger.debug("dbgpu unavailable, using static bandwidth only: %s", exc)
+        return None, None
+    index: dict[str, str] = {}
+    for canonical in db.names:
+        index.setdefault(_normalize_detected_name(canonical).lower(), canonical)
+    return db, index
+
+
+def _dbgpu_bandwidth(name: str, vram_bytes: int | None) -> float | None:
+    """Strict dbgpu bandwidth lookup. Never fuzzy-matches a variant away."""
+    db, index = _dbgpu_index()
+    if db is None or index is None:
+        return None
+    query = _normalize_detected_name(name).lower()
+    if not query:
+        return None
+
+    if query in index:
+        candidates = [index[query]]
+    else:
+        candidates = [
+            original
+            for normalized, original in index.items()
+            if normalized.startswith(query + " ")
+            and _VRAM_SUFFIX_RE.match(normalized[len(query) :])
+        ]
+        if not candidates:
+            return None
+        if vram_bytes and len(candidates) > 1:
+            target_gb = round(vram_bytes / _GiB)
+            same_vram = [c for c in candidates if _vram_gb(c) == target_gb]
+            if same_vram:
+                candidates = same_vram
+
+    canonical = min(candidates, key=len)
+    try:
+        spec = db[canonical]
+    except KeyError:  # pragma: no cover - canonical comes from the index
+        return None
+    bandwidth = getattr(spec, "memory_bandwidth_gb_s", None)
+    return float(bandwidth) if bandwidth else None
+
+
+def resolve_detected_bandwidth(
+    name: str, vram_bytes: int | None = None
+) -> float | None:
+    """Best memory bandwidth (GB/s) for a detected GPU, or ``None`` if unknown.
+
+    Curated ``GPU_BANDWIDTH`` wins; dbgpu fills the gaps. ``vram_bytes`` (when
+    known) disambiguates same-name cards that ship in multiple VRAM bins.
+    """
+    if not name:
+        return None
+    return _static_bandwidth(name) or _dbgpu_bandwidth(name, vram_bytes)

--- a/src/whichllm/hardware/gpu_db.py
+++ b/src/whichllm/hardware/gpu_db.py
@@ -60,6 +60,9 @@ def _normalize_detected_name(name: str) -> str:
     return _WHITESPACE_RE.sub(" ", text).strip()
 
 
+_SORTED_BW_KEYS = sorted(GPU_BANDWIDTH, key=len, reverse=True)
+
+
 def _substring_bandwidth(name: str) -> float | None:
     """Curated ``GPU_BANDWIDTH`` lookup (longest key first), mobile-aware.
 
@@ -70,7 +73,7 @@ def _substring_bandwidth(name: str) -> float | None:
         return None
     name_upper = name.upper()
     name_is_mobile = bool(_MOBILE_MARKER_RE.search(name))
-    for key in sorted(GPU_BANDWIDTH, key=len, reverse=True):
+    for key in _SORTED_BW_KEYS:
         if key.upper() in name_upper:
             if name_is_mobile and not _MOBILE_MARKER_RE.search(key):
                 continue
@@ -154,13 +157,19 @@ def _dbgpu_bandwidth(name: str, vram_bytes: int | None) -> float | None:
             if same_vram:
                 candidates = same_vram
 
-    canonical = min(candidates, key=len)
-    try:
-        spec = db[canonical]
-    except KeyError:  # pragma: no cover - canonical comes from the index
-        return None
-    bandwidth = getattr(spec, "memory_bandwidth_gb_s", None)
-    return float(bandwidth) if bandwidth else None
+    # If several VRAM bins remain (VRAM unknown or no bin matched it), take the
+    # lowest bandwidth among them: an ambiguous match must never over-promise
+    # speed. Bins of the same card usually share one value anyway.
+    bandwidths: list[float] = []
+    for canonical in candidates:
+        try:
+            spec = db[canonical]
+        except KeyError:  # pragma: no cover - canonical comes from the index
+            continue
+        bandwidth = getattr(spec, "memory_bandwidth_gb_s", None)
+        if bandwidth:
+            bandwidths.append(float(bandwidth))
+    return min(bandwidths) if bandwidths else None
 
 
 def resolve_detected_bandwidth(

--- a/src/whichllm/hardware/nvidia.py
+++ b/src/whichllm/hardware/nvidia.py
@@ -6,7 +6,8 @@ import logging
 import re
 import subprocess
 
-from whichllm.constants import GPU_BANDWIDTH, NVIDIA_COMPUTE_CAPABILITY, _GiB
+from whichllm.constants import NVIDIA_COMPUTE_CAPABILITY, _GiB
+from whichllm.hardware.gpu_db import _static_bandwidth, resolve_detected_bandwidth
 from whichllm.hardware.types import GPUInfo
 
 logger = logging.getLogger(__name__)
@@ -23,12 +24,9 @@ def _lookup_compute_capability(name: str) -> tuple[int, int] | None:
 
 
 def _lookup_bandwidth(name: str) -> float | None:
-    name_upper = name.upper()
-    # Try longer matches first (e.g. "RTX 4080 SUPER" before "RTX 4080")
-    for key in sorted(GPU_BANDWIDTH, key=len, reverse=True):
-        if key.upper() in name_upper:
-            return GPU_BANDWIDTH[key]
-    return None
+    """Curated GPU_BANDWIDTH lookup. Kept for regression tests; live detection
+    goes through ``resolve_detected_bandwidth``, which also consults dbgpu."""
+    return _static_bandwidth(name)
 
 
 def _is_unified_memory_nvidia_gpu(name: str) -> bool:
@@ -62,7 +60,7 @@ def _make_nvidia_gpu(
         vram_bytes=vram_bytes,
         compute_capability=_lookup_compute_capability(name),
         cuda_version=cuda_version,
-        memory_bandwidth_gbps=_lookup_bandwidth(name),
+        memory_bandwidth_gbps=resolve_detected_bandwidth(name, vram_bytes),
         shared_memory=shared_memory,
     )
 

--- a/src/whichllm/hardware/windows.py
+++ b/src/whichllm/hardware/windows.py
@@ -7,7 +7,8 @@ import logging
 import re
 import subprocess
 
-from whichllm.constants import AMD_SHARED_MEMORY_APU_MARKERS, GPU_BANDWIDTH, _GiB
+from whichllm.constants import AMD_SHARED_MEMORY_APU_MARKERS, _GiB
+from whichllm.hardware.gpu_db import resolve_detected_bandwidth
 from whichllm.hardware.types import GPUInfo
 
 logger = logging.getLogger(__name__)
@@ -18,14 +19,6 @@ _WINDOWS_DISCRETE_VRAM_FLOORS: tuple[tuple[str, int], ...] = (
     # known floor instead of trusting the capped value.
     ("RX 9060 XT", 8 * _GiB),
 )
-
-
-def _lookup_bandwidth(name: str) -> float | None:
-    name_upper = name.upper()
-    for key in sorted(GPU_BANDWIDTH, key=len, reverse=True):
-        if key.upper() in name_upper:
-            return GPU_BANDWIDTH[key]
-    return None
 
 
 def _vendor_from_name(name: str) -> str | None:
@@ -182,7 +175,7 @@ def detect_windows_gpus() -> list[GPUInfo]:
                 name=name,
                 vendor=vendor,
                 vram_bytes=vram_bytes,
-                memory_bandwidth_gbps=_lookup_bandwidth(name),
+                memory_bandwidth_gbps=resolve_detected_bandwidth(name, vram_bytes),
                 shared_memory=shared_memory,
             )
         )

--- a/tests/test_gpu_db.py
+++ b/tests/test_gpu_db.py
@@ -1,0 +1,118 @@
+"""Tests for dbgpu-backed bandwidth resolution on detected hardware.
+
+The detection path must never give a laptop/mobile card its desktop bandwidth
+(issues #74, #61, #93). These tests pin the strict matching rules: curated
+values win, the curated lookup is mobile-aware, dbgpu fills gaps, and an
+unknown card resolves to None rather than a wrong guess.
+"""
+
+from whichllm.hardware.gpu_db import (
+    _normalize_detected_name,
+    _static_bandwidth,
+    resolve_detected_bandwidth,
+)
+
+_GiB = 1024**3
+
+
+# --- normalization ---------------------------------------------------------
+
+
+def test_normalize_strips_vendor_trademark_and_maps_laptop_to_mobile():
+    assert (
+        _normalize_detected_name("NVIDIA GeForce RTX 5090 Laptop GPU")
+        == "GeForce RTX 5090 Mobile"
+    )
+    assert _normalize_detected_name("Intel(R) Arc(TM) A770 Graphics") == "Arc A770"
+    assert _normalize_detected_name("AMD Radeon RX 6750 XT") == "Radeon RX 6750 XT"
+
+
+def test_normalize_empty_or_vendor_only():
+    assert _normalize_detected_name("") == ""
+    assert _normalize_detected_name("AMD") == ""
+
+
+def test_normalize_adds_space_to_vram_bin_suffix():
+    # #98: drivers write "12GB", dbgpu writes "12 GB".
+    assert _normalize_detected_name("NVIDIA RTX A2000 12GB") == "RTX A2000 12 GB"
+
+
+# --- curated lookup is mobile-aware ---------------------------------------
+
+
+def test_static_bandwidth_desktop_key_does_not_claim_laptop_card():
+    # "RTX 5090" desktop key (1792) must not match a Laptop driver name.
+    assert _static_bandwidth("NVIDIA GeForce RTX 5090 Laptop GPU") is None
+    # The desktop card itself still resolves from the curated table.
+    assert _static_bandwidth("NVIDIA GeForce RTX 5090") == 1792.0
+
+
+def test_static_bandwidth_keeps_curated_laptop_entry():
+    # A curated key that is itself a laptop entry stays authoritative.
+    assert _static_bandwidth("NVIDIA RTX A3000 Laptop GPU") == 264.0
+
+
+# --- end-to-end resolution -------------------------------------------------
+
+
+def test_resolve_desktop_uses_curated_value():
+    assert resolve_detected_bandwidth("NVIDIA GeForce RTX 5090") == 1792.0
+
+
+def test_resolve_laptop_5090_is_mobile_not_desktop():
+    # The bug in #74: a laptop 5090 must not inherit the 1792 desktop value.
+    bw = resolve_detected_bandwidth("NVIDIA GeForce RTX 5090 Laptop GPU", 24 * _GiB)
+    assert bw is not None
+    assert bw < 1500.0  # mobile 5090 is ~896 GB/s, nowhere near desktop 1792
+
+
+def test_resolve_a3000_laptop_preserves_curated_264():
+    assert resolve_detected_bandwidth("NVIDIA RTX A3000 Laptop GPU", 6 * _GiB) == 264.0
+
+
+def test_resolve_rx_6750_xt():
+    # #61: originally None. The curated table now carries it (#68); dbgpu
+    # would agree (432 GB/s) if the curated entry ever went away.
+    bw = resolve_detected_bandwidth("AMD Radeon RX 6750 XT", 12 * _GiB)
+    assert bw == 432.0
+
+
+def test_resolve_variant_qualifier_is_preserved():
+    # "RTX 4060 Ti" must not collapse to the non-Ti "RTX 4060".
+    bw = resolve_detected_bandwidth("NVIDIA GeForce RTX 4060 Ti", 16 * _GiB)
+    assert bw is not None
+    # 4060 (non-Ti) is 272 GB/s; the Ti is 288. Either way it must be a real,
+    # positive value and not desktop-flagship sized.
+    assert 200 < bw < 400
+
+
+def test_resolve_unknown_gpu_returns_none_not_wrong_guess():
+    # Arc Pro B70 is not in dbgpu yet: better None than a fuzzy mismatch.
+    assert resolve_detected_bandwidth("Intel(R) Arc(TM) Pro B70 Graphics") is None
+
+
+def test_resolve_empty_name_returns_none():
+    assert resolve_detected_bandwidth("") is None
+    assert resolve_detected_bandwidth("Some Totally Made Up GPU 9xZ") is None
+
+
+def test_resolve_known_amd_desktop_from_curated_table():
+    assert resolve_detected_bandwidth("AMD Radeon RX 9070 XT") == 640.0
+
+
+def test_resolve_a2000_12gb_vram_bin_from_dbgpu():
+    # #98: "NVIDIA RTX A2000 12GB" reported BW: N/A. dbgpu names the bin
+    # "RTX A2000 12 GB" (288 GB/s); the normalizer must bridge the spacing.
+    assert resolve_detected_bandwidth("NVIDIA RTX A2000 12GB", 12 * _GiB) == 288.0
+
+
+def test_static_bandwidth_compound_lspci_name():
+    # Ported from amd.py (#68): compound lspci names resolve via segment
+    # splitting, first matching segment wins, "RX " prefix retried for bare
+    # segments.
+    compound = "Navi 22 [Radeon RX 6700/6700 XT/6750 XT / 6800M/6850M XT]"
+    bw = _static_bandwidth(compound)
+    assert bw is not None
+    assert bw > 0
+    # The same answer flows through the public resolver.
+    assert resolve_detected_bandwidth(compound, 12 * _GiB) == bw

--- a/tests/test_nvidia_detection.py
+++ b/tests/test_nvidia_detection.py
@@ -50,6 +50,31 @@ def test_nvidia_smi_fallback_applies_rtx_a3000_laptop_catalog(monkeypatch):
     assert gpus[0].memory_bandwidth_gbps == 264.0
 
 
+def test_nvidia_smi_fallback_resolves_laptop_5090_via_dbgpu(monkeypatch):
+    # Regression for #74: a laptop RTX 5090 must not inherit the desktop
+    # 1792 GB/s bandwidth. dbgpu carries "GeForce RTX 5090 Mobile" (~896).
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "pynvml":
+            raise ImportError
+        return real_import(name, *args, **kwargs)
+
+    def fake_run(*args, **kwargs):
+        return SimpleNamespace(stdout="NVIDIA GeForce RTX 5090 Laptop GPU, 24564 MiB\n")
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    gpus = detect_nvidia_gpus()
+
+    assert len(gpus) == 1
+    assert gpus[0].name == "NVIDIA GeForce RTX 5090 Laptop GPU"
+    bw = gpus[0].memory_bandwidth_gbps
+    assert bw is not None
+    assert bw < 1500.0  # mobile ~896, not the 1792 desktop value
+
+
 def test_nvidia_smi_fallback_when_nvml_init_fails(monkeypatch):
     class FakeNVMLError(Exception):
         pass


### PR DESCRIPTION
## What

Detection (nvidia / amd / windows paths) resolved memory bandwidth from the hand-curated `GPU_BANDWIDTH` table only. Any card not in the table got `BW: N/A`, a `0.0 tok/s` estimate, and oversized recommendations. This is the single root cause behind #74 and #98, and the same failure mode reported in #61 and #93.

This PR adds `hardware/gpu_db.py`, a strict resolver that all three detection paths now share:

1. The curated table stays authoritative and wins every lookup, so no existing card changes value. New mobile guard: a Laptop / Mobile / Max-Q driver name can never match a desktop key ("RTX 5090" no longer swallows "RTX 5090 Laptop GPU", which would have reported 1792 GB/s instead of 896).
2. dbgpu (the TechPowerUp database we already ship for `--gpu` simulation, 2824 GPUs) fills the gaps, via strict matching only: an exact normalized-name hit, or name plus VRAM-size bin disambiguated by detected VRAM. Never fuzzy, so a Ti / SUPER / Mobile qualifier can't silently land on the wrong card.
3. If both miss, bandwidth stays None. A wrong guess is worse than no data.

Name normalization bridges driver vocabulary to dbgpu vocabulary: `Laptop GPU` to `Mobile`, vendor words and `(TM)`/`(R)` stripped, and `12GB` to `12 GB` (the #98 case).

The compound-lspci splitting from #68 moved into the new module unchanged; `amd._lookup_bandwidth` stays as a thin alias so its regression tests keep their target.

## Why

Biggest complaint cluster since the repo got traction: uncatalogued GPUs produce confidently wrong rankings. The simulator already used dbgpu; detection was the only path still limited to the hand-written table.

Closes #74. Closes #98. Refs #93 (Arc Pro B70 is not in dbgpu yet, and its discrete-vs-shared misdetection is a separate fix). Refs #47.

## Testing

- [x] Tests pass (`pytest`): 329 passed, 16 new (`tests/test_gpu_db.py` pins the mobile guard, VRAM-bin disambiguation, compound names, and the refusal to guess; plus an nvidia-smi regression test for the laptop 5090)
- [x] Verified resolutions: A2000 12GB 288, 5090 Laptop 896, desktop 5090 unchanged 1792, A3000 Laptop curated 264 preserved, RX 6750 XT 432, Arc Pro B70 None
- [x] Tested on real hardware: Apple M2 (`whichllm hardware`, Apple path untouched)

## Notes

dbgpu import failure degrades to curated-only instead of raising, so detection can never crash from the fallback.
