### PR TITLE
feat: add T5 model family support (lineage scoring + fetch + plan)

### DIFF
--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -182,6 +182,7 @@ Examples of tracked lineages include:
 - Kimi
 - Granite
 - OLMo
+- T5 (incl. Flan-T5, mT5, ByT5, T5Gemma)
 
 ## Benchmark markers
 

--- a/src/whichllm/data/lineage.py
+++ b/src/whichllm/data/lineage.py
@@ -48,10 +48,12 @@ MODEL_LINEAGE_VERSIONS: dict[str, list[tuple[str, int]]] = {
         (r"deepseek-coder(?!-v2)", 1),
     ],
     "gemma": [
-        (r"gemma-?4", 4),
-        (r"gemma-?3", 3),
-        (r"gemma-?2", 2),
-        (r"gemma(?!-?[2-9])", 1),
+        # (?<!t5) so the "gemma" inside a T5Gemma id is not misread as a
+        # Gemma generation (T5Gemma is handled by the "t5" family instead).
+        (r"(?<!t5)gemma-?4", 4),
+        (r"(?<!t5)gemma-?3", 3),
+        (r"(?<!t5)gemma-?2", 2),
+        (r"(?<!t5)gemma(?!-?[2-9])", 1),
     ],
     "phi": [
         (r"phi-?5", 5),
@@ -129,6 +131,22 @@ MODEL_LINEAGE_VERSIONS: dict[str, list[tuple[str, int]]] = {
         (r"yi-lightning", 3),
         (r"yi-1\.5", 2),
         (r"yi-(6b|9b|34b)(?!.*1\.5)", 1),
+    ],
+    "t5": [
+        # Encoder-decoder T5 family, ordered newest -> oldest. The bare "t5"
+        # fallback is boundary-guarded because "t5" is a collision-prone
+        # substring (e.g. "gpt5"); every named variant is matched before it.
+        (r"t5-?gemma", 5),  # T5Gemma (2025) — Gemma-adapted encoder-decoder
+        (r"flan-?t5", 4),  # Flan-T5 instruction-tuned (2022)
+        (r"flan-?ul2", 4),  # Flan-UL2 (2023)
+        (r"codet5p", 3),  # CodeT5+ (2023); before codet5 since it's a superset
+        (r"ul2", 3),  # UL2 (2022)
+        (r"code-?t5", 2),  # CodeT5 (2021)
+        (r"long-?t5", 2),  # LongT5 (2021)
+        (r"byt5", 2),  # ByT5 byte-level (2021)
+        (r"mt5", 2),  # mT5 multilingual (2020)
+        (r"t5-?v1[._]1", 2),  # T5 v1.1 / LM-adapted (2020)
+        (r"(?<![a-z0-9])t5(?![a-z])", 1),  # original T5 (2019)
     ],
 }
 

--- a/src/whichllm/data/lineage.py
+++ b/src/whichllm/data/lineage.py
@@ -48,12 +48,12 @@ MODEL_LINEAGE_VERSIONS: dict[str, list[tuple[str, int]]] = {
         (r"deepseek-coder(?!-v2)", 1),
     ],
     "gemma": [
-        # (?<!t5) so the "gemma" inside a T5Gemma id is not misread as a
-        # Gemma generation (T5Gemma is handled by the "t5" family instead).
-        (r"(?<!t5)gemma-?4", 4),
-        (r"(?<!t5)gemma-?3", 3),
-        (r"(?<!t5)gemma-?2", 2),
-        (r"(?<!t5)gemma(?!-?[2-9])", 1),
+        # Avoid reading the "gemma" segment inside T5Gemma ids as a Gemma
+        # generation. T5Gemma is handled by the "t5" family instead.
+        (r"(?<!t5)(?<!t5[-_])gemma-?4", 4),
+        (r"(?<!t5)(?<!t5[-_])gemma-?3", 3),
+        (r"(?<!t5)(?<!t5[-_])gemma-?2", 2),
+        (r"(?<!t5)(?<!t5[-_])gemma(?!-?[2-9])", 1),
     ],
     "phi": [
         (r"phi-?5", 5),
@@ -136,7 +136,7 @@ MODEL_LINEAGE_VERSIONS: dict[str, list[tuple[str, int]]] = {
         # Encoder-decoder T5 family, ordered newest -> oldest. The bare "t5"
         # fallback is boundary-guarded because "t5" is a collision-prone
         # substring (e.g. "gpt5"); every named variant is matched before it.
-        (r"t5-?gemma", 5),  # T5Gemma (2025) — Gemma-adapted encoder-decoder
+        (r"t5[-_]?gemma", 5),  # T5Gemma (2025) — Gemma-adapted encoder-decoder
         (r"flan-?t5", 4),  # Flan-T5 instruction-tuned (2022)
         (r"flan-?ul2", 4),  # Flan-UL2 (2023)
         (r"codet5p", 3),  # CodeT5+ (2023); before codet5 since it's a superset

--- a/tests/test_benchmark_lookup.py
+++ b/tests/test_benchmark_lookup.py
@@ -1,6 +1,7 @@
 """Tests for benchmark lookup direct/inherited semantics."""
 
 from whichllm.models.benchmark import (
+    _lineage_recency_factor,
     build_line_bucket_index,
     build_score_index,
     lookup_benchmark,
@@ -148,3 +149,10 @@ def test_lookup_benchmark_evidence_line_uses_size_aware_interpolation():
     assert result.score is not None
     assert 65.0 < result.score < 85.0
     assert result.confidence > 0.2
+
+
+def test_lineage_recency_t5gemma_variants_are_not_demoted_as_old_gemma():
+    assert _lineage_recency_factor("google/t5gemma-4b") == 1.0
+    assert _lineage_recency_factor("google/t5-gemma-4b") == 1.0
+    assert _lineage_recency_factor("google/t5_gemma-4b") == 1.0
+    assert _lineage_recency_factor("google/gemma-2-2b") < 1.0

--- a/tests/test_p1_p3_regressions.py
+++ b/tests/test_p1_p3_regressions.py
@@ -228,6 +228,19 @@ def test_p2_lineage_covers_llama_deepseek_gemma_phi():
     )
 
 
+def test_p2_lineage_covers_t5_variants_without_gemma_collision():
+    assert _generation_bonus("google/t5gemma-4b") > _generation_bonus(
+        "google/flan-t5-xl"
+    )
+    assert _generation_bonus("google/t5-gemma-4b") == _generation_bonus(
+        "google/t5gemma-4b"
+    )
+    assert _generation_bonus("google/t5_gemma-4b") == _generation_bonus(
+        "google/t5gemma-4b"
+    )
+    assert _generation_bonus("openai/gpt5-test") == 0.0
+
+
 def test_p2_unknown_family_gets_zero_bonus():
     assert _generation_bonus("random-org/random-model-7b") == 0.0
 


### PR DESCRIPTION
## Summary

Adds end-to-end support for the **T5 model family** — T5, Flan-T5, mT5, ByT5,
LongT5, UL2, CodeT5, and 2025's T5Gemma — so they are scored, fetched, ranked,
and usable via `whichllm plan` / `run