### PR TITLE
Add python module entrypoint

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -114,6 +114,28 @@ The caches live under:
 ~/.cache/whichllm/
 ```
 
+## `uvx` fails with `realpath: command not found`
+
+Some older macOS versions do not include a `realpath` command. If the `uvx`
+launcher fails before whichllm starts, with output like:
+
+```text
+realpath: command not found
+/Users/.../python: No such file or directory
+```
+
+run whichllm through Python's module entry point instead:
+
+```bash
+uvx --from whichllm python -m whichllm
+```
+
+Pass normal whichllm arguments after the module name:
+
+```bash
+uvx --from whichllm python -m whichllm --gpu "RTX 4090"
+```
+
 ## The top pick has `~`, `!sr`, or `?`
 
 These markers describe benchmark evidence:

--- a/src/whichllm/__main__.py
+++ b/src/whichllm/__main__.py
@@ -1,0 +1,7 @@
+"""Module entry point for ``python -m whichllm``."""
+
+from whichllm.cli import app
+
+
+if __name__ == "__main__":
+    app()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ import pytest
 from typer import Exit
 
 import whichllm.cli as cli_mod
+import whichllm.__main__ as main_mod
 from whichllm.cli import (
     _auto_min_params_for_profile,
     _fill_missing_published_at,
@@ -98,6 +99,10 @@ def test_version_option_prints_version_and_exits():
     result = runner.invoke(app, ["--version"])
     assert result.exit_code == 0
     assert _current_version() in result.stdout
+
+
+def test_module_entrypoint_uses_cli_app():
+    assert main_mod.app is app
 
 
 def test_format_fetch_error_uses_exception_class_when_message_is_empty():


### PR DESCRIPTION
 ## What

  Adds a `python -m whichllm` module entrypoint and documents it as a fallback command for environments where the generated `uvx` launcher fails before whichllm starts.

  ## Why

  On older macOS versions, `uvx whichllm@latest` can fail before invoking whichllm because the generated launcher depends on `realpath`, which may not be available:

  ```text
  realpath: command not found
  /Users/.../python: No such file or directory

  This PR does not change the existing whichllm console script. It adds a portable fallback:

  uvx --from whichllm python -m whichllm

  ## Testing

  - [ ] Tests pass (pytest)
  - [x] New tests added
  - [ ] Tested on real hardware (if hardware-related)

  Verified locally with:

  PYTHONPATH=/Users/hannibal/whichllm/src /Users/hannibal/.cache/uv/archive-v0/b_ZZfBOyPpAdyWVq/bin/python -m whichllm --version

  Output:

  0.5.10

  Full uv run pytest was blocked locally by network/TLS download failures while installing dependencies.

  ## Notes

  This is a workaround for old launcher environments, not a replacement for fixing launcher generation in uv itself.