### PR TITLE
fix: read and write model caches as UTF-8

### DIFF
--- a/src/whichllm/models/benchmark.py
+++ b/src/whichllm/models/benchmark.py
@@ -45,7 +45,7 @@ def load_benchmark_cache() -> dict[str, float] | None:
     if not BENCHMARK_CACHE.exists():
         return None
     try:
-        data = json.loads(BENCHMARK_CACHE.read_text())
+        data = json.loads(BENCHMARK_CACHE.read_text(encoding="utf-8"))
         cached_at = data.get("cached_at", 0)
         if time.time() - cached_at > DEFAULT_TTL_SECONDS:
             logger.debug("Benchmark cache expired")
@@ -60,7 +60,7 @@ def save_benchmark_cache(scores: dict[str, float]) -> None:
     """Save benchmark scores to cache."""
     CACHE_DIR.mkdir(parents=True, exist_ok=True)
     data = {"cached_at": time.time(), "scores": scores}
-    BENCHMARK_CACHE.write_text(json.dumps(data, ensure_ascii=False))
+    BENCHMARK_CACHE.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
     logger.debug(f"Saved {len(scores)} benchmark scores to cache")
 
 

--- a/src/whichllm/models/cache.py
+++ b/src/whichllm/models/cache.py
@@ -25,7 +25,7 @@ def load_cache() -> list[dict] | None:
         return None
 
     try:
-        data = json.loads(CACHE_FILE.read_text())
+        data = json.loads(CACHE_FILE.read_text(encoding="utf-8"))
         cached_at = data.get("cached_at", 0)
         if time.time() - cached_at > DEFAULT_TTL_SECONDS:
             logger.debug("Cache expired")
@@ -43,5 +43,5 @@ def save_cache(models: list[dict]) -> None:
         "cached_at": time.time(),
         "models": models,
     }
-    CACHE_FILE.write_text(json.dumps(data, ensure_ascii=False))
+    CACHE_FILE.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
     logger.debug(f"Saved {len(models)} models to cache")

--- a/tests/test_cache_encoding.py
+++ b/tests/test_cache_encoding.py
@@ -1,0 +1,65 @@
+"""Regression tests for cross-platform cache encoding."""
+
+from __future__ import annotations
+
+import json
+import time
+
+import whichllm.models.benchmark as benchmark_mod
+import whichllm.models.cache as cache_mod
+
+
+class _ReadableCacheFile:
+    def __init__(self, payload: dict):
+        self.payload = payload
+        self.encoding = None
+
+    def exists(self) -> bool:
+        return True
+
+    def read_text(self, *, encoding: str | None = None) -> str:
+        self.encoding = encoding
+        return json.dumps(self.payload, ensure_ascii=False)
+
+
+class _WritableCacheFile:
+    def __init__(self):
+        self.encoding = None
+        self.text = None
+
+    def write_text(self, text: str, *, encoding: str | None = None) -> int:
+        self.encoding = encoding
+        self.text = text
+        return len(text)
+
+
+def test_model_cache_reads_and_writes_utf8(monkeypatch, tmp_path):
+    reader = _ReadableCacheFile(
+        {"cached_at": time.time(), "models": [{"id": "test/Omega-Ω"}]}
+    )
+    monkeypatch.setattr(cache_mod, "CACHE_FILE", reader)
+    assert cache_mod.load_cache() == [{"id": "test/Omega-Ω"}]
+    assert reader.encoding == "utf-8"
+
+    writer = _WritableCacheFile()
+    monkeypatch.setattr(cache_mod, "CACHE_DIR", tmp_path)
+    monkeypatch.setattr(cache_mod, "CACHE_FILE", writer)
+    cache_mod.save_cache([{"id": "test/Omega-Ω"}])
+    assert writer.encoding == "utf-8"
+    assert "Ω" in writer.text
+
+
+def test_benchmark_cache_reads_and_writes_utf8(monkeypatch, tmp_path):
+    reader = _ReadableCacheFile(
+        {"cached_at": time.time(), "scores": {"test/Omega-Ω": 1.0}}
+    )
+    monkeypatch.setattr(benchmark_mod, "BENCHMARK_CACHE", reader)
+    assert benchmark_mod.load_benchmark_cache() == {"test/Omega-Ω": 1.0}
+    assert reader.encoding == "utf-8"
+
+    writer = _WritableCacheFile()
+    monkeypatch.setattr(benchmark_mod, "CACHE_DIR", tmp_path)
+    monkeypatch.setattr(benchmark_mod, "BENCHMARK_CACHE", writer)
+    benchmark_mod.save_benchmark_cache({"test/Omega-Ω": 1.0})
+    assert writer.encoding == "utf-8"
+    assert "Ω" in writer.text


### PR DESCRIPTION
## What

Fixes the local model and benchmark caches so they always read and write JSON as UTF-8.

This fixes the Windows crash from #117 where model metadata containing characters such as `Ω` could fail under the system locale encoding.

## Why

On Windows, `pathlib.read_text()` and `write_text()` use the active locale when no encoding is passed. The cache already writes JSON with `ensure_ascii=False`, so Unicode model metadata can hit `charmap` errors on cp1252 systems.

#118 identified the right fix. I kept this PR narrow because that branch currently includes unrelated GPU detection commits and conflicts with main.

## Tests

Full local test suite passes.
