### PR TITLE
feat: add full-GPU fit filter

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -20,6 +20,8 @@ Common options:
 | `--context-length`, `-c` | Context length used for KV cache estimation. Accepts integers or `k` shorthand such as `64k`. Default: `4096` |
 | `--quant`, `-q` | Keep only a quantization type such as `Q4_K_M` |
 | `--min-speed` | Keep only models above a tok/s estimate |
+| `--fit` | Runtime fit filter: `any` or `full-gpu` |
+| `--gpu-only` | Alias for `--fit full-gpu`; excludes partial offload and CPU-only candidates |
 | `--profile` | Ranking profile: `general`, `coding`, `vision`, `math`, `any` |
 | `--evidence` | Benchmark evidence filter: `strict`, `base`, `any` |
 | `--direct` | Alias for `--evidence strict` |
@@ -43,6 +45,8 @@ whichllm --gpu "RTX 4090" --gpu "RTX 3090"
 whichllm --gpu "RTX 4090, RTX 3090"
 whichllm --profile coding --top 5
 whichllm --context-length 64k
+whichllm --gpu-only
+whichllm --fit full-gpu --status
 whichllm --evidence strict
 whichllm --status
 whichllm --json | jq '.models[0]'

--- a/src/whichllm/cli.py
+++ b/src/whichllm/cli.py
@@ -96,6 +96,17 @@ def _resolve_evidence_mode(evidence: str, direct: bool) -> str:
     return mode
 
 
+def _resolve_fit_filter(fit: str, gpu_only: bool) -> str:
+    """Resolve runtime fit filtering, keeping --gpu-only as a short alias."""
+    mode = fit.lower().replace("_", "-")
+    if mode not in {"any", "full-gpu"}:
+        console.print("[red]Error:[/] --fit must be one of: any, full-gpu.")
+        raise typer.Exit(code=1)
+    if gpu_only:
+        return "full_gpu"
+    return "full_gpu" if mode == "full-gpu" else "any"
+
+
 def _apply_gpu_overrides(
     hardware: HardwareInfo,
     cpu_only: bool,
@@ -222,6 +233,16 @@ def main(
     min_speed: Optional[float] = typer.Option(
         None, "--min-speed", help="Minimum tok/s filter"
     ),
+    fit: str = typer.Option(
+        "any",
+        "--fit",
+        help="Runtime fit filter: any | full-gpu",
+    ),
+    gpu_only: bool = typer.Option(
+        False,
+        "--gpu-only",
+        help="Only show models that fit fully in GPU VRAM",
+    ),
     evidence: str = typer.Option(
         "any",
         "--evidence",
@@ -267,6 +288,7 @@ def main(
     _validate_gpu_flags(cpu_only, gpu, vram)
     profile = _validate_profile(profile)
     evidence_mode = _resolve_evidence_mode(evidence, direct)
+    fit_filter = _resolve_fit_filter(fit, gpu_only)
 
     from rich.progress import Progress, SpinnerColumn, TextColumn
 
@@ -365,6 +387,7 @@ def main(
             require_direct_top=True,
             min_params_b=auto_min_params,
             evidence_filter=evidence_mode,
+            fit_filter=fit_filter,
         )
 
         # 自動しきい値で候補ゼロなら緩和して表示を維持する
@@ -381,6 +404,7 @@ def main(
                 require_direct_top=True,
                 min_params_b=None,
                 evidence_filter=evidence_mode,
+                fit_filter=fit_filter,
             )
 
         # 上位候補の公開日時が欠けている場合のみ補完して表示品質を上げる
@@ -399,10 +423,22 @@ def main(
     if json_output:
         display_json(results, hardware)
     else:
+        empty_message = None
+        if fit_filter == "full_gpu":
+            empty_message = (
+                "No full-GPU models found for this hardware. "
+                "Remove --gpu-only or use --fit any to include partial offload "
+                "and CPU-only candidates."
+            )
         console.print()
         display_hardware(hardware)
         console.print()
-        display_ranking(results, has_gpu=bool(hardware.gpus), show_status=status)
+        display_ranking(
+            results,
+            has_gpu=bool(hardware.gpus),
+            show_status=status,
+            empty_message=empty_message,
+        )
         console.print()
 
 

--- a/src/whichllm/engine/ranker.py
+++ b/src/whichllm/engine/ranker.py
@@ -650,6 +650,7 @@ def rank_models(
     require_direct_top: bool = True,
     min_params_b: float | None = None,
     evidence_filter: str = "any",
+    fit_filter: str = "any",
 ) -> list[CompatibilityResult]:
     """Rank models by quality for the given hardware. Returns top N results."""
     results: list[CompatibilityResult] = []
@@ -751,6 +752,8 @@ def rank_models(
                 continue
             compat = check_compatibility(model, variant, hardware, context_length)
             if not compat.can_run:
+                continue
+            if fit_filter == "full_gpu" and compat.fit_type != "full_gpu":
                 continue
 
             tok_per_sec = estimate_tok_per_sec(

--- a/src/whichllm/output/ranking.py
+++ b/src/whichllm/output/ranking.py
@@ -144,11 +144,12 @@ def display_ranking(
     *,
     has_gpu: bool = True,
     show_status: bool = False,
+    empty_message: str | None = None,
 ) -> None:
     """Display ranked model table."""
     if not results:
         _console.console.print(
-            "[yellow]No compatible models found for your hardware.[/]"
+            f"[yellow]{empty_message or 'No compatible models found for your hardware.'}[/]"
         )
         return
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,6 +17,7 @@ from whichllm.cli import (
     _pick_gguf_variant,
     _resolve_ranked_gguf_for_run,
     _resolve_evidence_mode,
+    _resolve_fit_filter,
     _search_model,
     _validate_evidence,
     app,
@@ -186,6 +187,90 @@ def test_validate_evidence_rejects_unknown_mode():
 
 def test_resolve_evidence_mode_direct_alias_wins():
     assert _resolve_evidence_mode("base", direct=True) == "strict"
+
+
+def test_resolve_fit_filter_accepts_gpu_only_alias():
+    assert _resolve_fit_filter("any", gpu_only=False) == "any"
+    assert _resolve_fit_filter("full-gpu", gpu_only=False) == "full_gpu"
+    assert _resolve_fit_filter("full_gpu", gpu_only=False) == "full_gpu"
+    assert _resolve_fit_filter("any", gpu_only=True) == "full_gpu"
+
+
+def test_resolve_fit_filter_rejects_unknown_mode():
+    with pytest.raises(Exit):
+        _resolve_fit_filter("partial", gpu_only=False)
+
+
+def test_main_passes_gpu_only_fit_filter(monkeypatch):
+    model = ModelInfo(
+        id="org/Test-7B",
+        family_id="test-7b",
+        name="Test-7B",
+        parameter_count=7_000_000_000,
+        downloads=1,
+        likes=1,
+        published_at="2026-01-01T00:00:00.000Z",
+    )
+    captured: dict[str, object] = {}
+
+    def fake_rank_models(models, hardware, **kwargs):
+        captured["fit_filter"] = kwargs.get("fit_filter")
+        return [
+            CompatibilityResult(
+                model=model,
+                gguf_variant=None,
+                can_run=True,
+                vram_required_bytes=4 * 1024**3,
+                vram_available_bytes=8 * 1024**3,
+                fit_type="full_gpu",
+                quality_score=80.0,
+            )
+        ]
+
+    monkeypatch.setattr(
+        "whichllm.hardware.detector.detect_hardware", lambda: _hw_with_gpu(8)
+    )
+    monkeypatch.setattr("whichllm.models.cache.load_cache", lambda: [])
+    monkeypatch.setattr("whichllm.models.benchmark.load_benchmark_cache", lambda: {})
+    monkeypatch.setattr("whichllm.engine.ranker.rank_models", fake_rank_models)
+    monkeypatch.setattr(
+        "whichllm.output.display.display_hardware", lambda hardware: None
+    )
+    monkeypatch.setattr(
+        "whichllm.output.display.display_ranking",
+        lambda results, **kwargs: None,
+    )
+
+    result = CliRunner().invoke(app, ["--gpu-only"])
+
+    assert result.exit_code == 0
+    assert captured["fit_filter"] == "full_gpu"
+
+
+def test_main_empty_gpu_only_result_shows_fit_message(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def fake_rank_models(models, hardware, **kwargs):
+        return []
+
+    def fake_display_ranking(results, **kwargs):
+        captured["empty_message"] = kwargs.get("empty_message")
+
+    monkeypatch.setattr(
+        "whichllm.hardware.detector.detect_hardware", lambda: _hw_with_gpu(8)
+    )
+    monkeypatch.setattr("whichllm.models.cache.load_cache", lambda: [])
+    monkeypatch.setattr("whichllm.models.benchmark.load_benchmark_cache", lambda: {})
+    monkeypatch.setattr("whichllm.engine.ranker.rank_models", fake_rank_models)
+    monkeypatch.setattr(
+        "whichllm.output.display.display_hardware", lambda hardware: None
+    )
+    monkeypatch.setattr("whichllm.output.display.display_ranking", fake_display_ranking)
+
+    result = CliRunner().invoke(app, ["--fit", "full-gpu", "--min-params", "1"])
+
+    assert result.exit_code == 0
+    assert "No full-GPU models found" in captured["empty_message"]
 
 
 # --------------- plan command tests ---------------

--- a/tests/test_ranker.py
+++ b/tests/test_ranker.py
@@ -785,6 +785,95 @@ def test_unknown_speed_heavy_partial_offload_does_not_top_rank():
         assert heavy.estimated_tok_per_sec == 0.0
 
 
+def test_fit_filter_full_gpu_excludes_partial_offload_and_cpu_only():
+    partial = ModelInfo(
+        id="org/Test-30B-GGUF",
+        family_id="test-30b",
+        name="Test-30B-GGUF",
+        parameter_count=30_000_000_000,
+        downloads=1000,
+        likes=100,
+        gguf_variants=[
+            GGUFVariant(
+                filename="test-30b-Q4_K_M.gguf",
+                quant_type="Q4_K_M",
+                file_size_bytes=18_000_000_000,
+            )
+        ],
+    )
+    full = ModelInfo(
+        id="org/Test-7B-GGUF",
+        family_id="test-7b",
+        name="Test-7B-GGUF",
+        parameter_count=7_000_000_000,
+        downloads=900,
+        likes=90,
+        gguf_variants=[
+            GGUFVariant(
+                filename="test-7b-Q4_K_M.gguf",
+                quant_type="Q4_K_M",
+                file_size_bytes=4_000_000_000,
+            )
+        ],
+    )
+    cpu_only = ModelInfo(
+        id="org/Test-60B-GGUF",
+        family_id="test-60b",
+        name="Test-60B-GGUF",
+        parameter_count=60_000_000_000,
+        downloads=800,
+        likes=80,
+        gguf_variants=[
+            GGUFVariant(
+                filename="test-60b-Q4_K_M.gguf",
+                quant_type="Q4_K_M",
+                file_size_bytes=36_000_000_000,
+            )
+        ],
+    )
+    hw = _make_hardware(vram_gb=8, bandwidth_gbps=300.0)
+    results = rank_models(
+        [partial, full, cpu_only],
+        hw,
+        top_n=10,
+        fit_filter="full_gpu",
+        task_profile="any",
+        require_direct_top=False,
+    )
+
+    assert [r.model.id for r in results] == ["org/Test-7B-GGUF"]
+    assert results[0].fit_type == "full_gpu"
+
+
+def test_fit_filter_full_gpu_returns_empty_when_no_full_gpu_candidate():
+    partial = ModelInfo(
+        id="org/Test-30B-GGUF",
+        family_id="test-30b",
+        name="Test-30B-GGUF",
+        parameter_count=30_000_000_000,
+        downloads=1000,
+        likes=100,
+        gguf_variants=[
+            GGUFVariant(
+                filename="test-30b-Q4_K_M.gguf",
+                quant_type="Q4_K_M",
+                file_size_bytes=18_000_000_000,
+            )
+        ],
+    )
+    hw = _make_hardware(vram_gb=8, bandwidth_gbps=300.0)
+    results = rank_models(
+        [partial],
+        hw,
+        top_n=10,
+        fit_filter="full_gpu",
+        task_profile="any",
+        require_direct_top=False,
+    )
+
+    assert results == []
+
+
 def test_multi_gpu_speed_confidence_is_low():
     from whichllm.engine.performance import estimate_tok_per_sec
 


### PR DESCRIPTION
## What

Adds a full-GPU fit filter to the main recommendation command.

Users can now run:

```bash
whichllm --gpu-only
whichllm --fit full-gpu
```

Both commands keep only candidates where `fit_type` is `full_gpu`. `--fit any` keeps the current behavior.

## Why

`--status` already shows whether a model is `full_gpu`, `partial_offload`, or `cpu_only`, but users who only want models that fit fully in VRAM still had to filter the results by hand.

## Notes

- `--gpu-only` is a short alias for `--fit full-gpu`
- partial offload and CPU-only candidates are excluded before results are shown
- when the filter removes every candidate, the CLI explains how to include partial offload again
- JSON output keeps the same shape and returns an empty `models` list when nothing matches

Fixes #119.