### PR TITLE
release: v0.5.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.5.11] - 2026-06-18
+
+### Added
+
+- Multi-GPU simulation for repeated `--gpu` flags, comma-separated GPU specs,
+  and count shorthand such as `2x RTX 4090`. The fit model uses a conservative
+  effective VRAM budget and keeps speed confidence low for split-device
+  recommendations. (#113)
+- `python -m whichllm` now runs the CLI entrypoint. (#116)
+- `--gpu-only` and `--fit full-gpu` now filter recommendations to models that
+  fit fully in GPU VRAM. `--fit any` keeps the existing behavior. (#119, #122)
+- T5 lineage support so T5-family models get version-aware benchmark handling.
+
+### Fixed
+
+- Fixed UTF-8 decoding for cached model and benchmark data on systems whose
+  default filesystem encoding is not UTF-8. (#121)
+- GTX 1650 simulation now distinguishes GDDR5 and GDDR6 variants by memory
+  clock instead of treating every card as the slower 128 GB/s model. (#115)
+- RAM reserve logic now uses a bounded reserve formula instead of a fixed 80%
+  usable-RAM cap, which avoids underestimating machines with more system
+  memory. (#103)
+
 ## [0.5.10] - 2026-06-11
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "whichllm"
-version = "0.5.10"
+version = "0.5.11"
 description = "Find the best LLM that runs on your hardware"
 authors = [{name = "Andyyyy64"}]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -547,7 +547,7 @@ wheels = [
 
 [[package]]
 name = "whichllm"
-version = "0.5.10"
+version = "0.5.11"
 source = { editable = "." }
 dependencies = [
     { name = "dbgpu", extra = ["fuzz"] },


### PR DESCRIPTION
## Summary
- bump the package version to 0.5.11
- document the multi-GPU simulation, full-GPU filter, cache encoding fix, GTX 1650 variant handling, and related changes in the changelog

## QA
- `uvx ruff check .`
- `uvx ruff format --check .`
- `uv run pytest` (377 passed)
- `uv run python -m compileall -q src tests`
- `uv run whichllm --version` -> `0.5.11`
- `uv run --with build python -m build`
- `uv run --with twine twine check dist/*`