### PR TITLE
fix: size FP16 and ternary (TQ1_0/TQ2_0) GGUF quant types correctly

### DIFF
--- a/src/whichllm/models/fetcher.py
+++ b/src/whichllm/models/fetcher.py
@@ -212,22 +212,41 @@ def _normalize_param_count(
     return extracted
 
 
+# Filename quant tokens that name the same format under a different spelling
+# than the canonical key used by QUANT_BYTES_PER_WEIGHT / QUANT_QUALITY_PENALTY.
+# llama.cpp GGUFs are frequently published as ``*-FP16.gguf`` / ``*-FP32.gguf``,
+# but the byte/penalty tables key full precision as ``F16`` / ``F32``. Without
+# this mapping the extracted token misses the table and _estimate_gguf_size
+# silently falls back to the Q4_K_M default, under-counting an FP16 GGUF ~3.5x.
+_QUANT_ALIASES = {
+    "FP16": "F16",
+    "FP32": "F32",
+}
+
+
 def _extract_quant_type(filename: str) -> str:
-    """Extract quantization type from GGUF filename."""
+    """Extract quantization type from a GGUF filename.
+
+    The returned key is canonicalized to match QUANT_BYTES_PER_WEIGHT (see the
+    ``test_extract_quant_type_keys_resolve_in_byte_table`` drift guard), so
+    callers can look it up directly. Returns ``"unknown"`` when nothing matches.
+    """
     # Common patterns: model-Q4_K_M.gguf, model.Q4_K_M.gguf
     patterns = [
         r"[.-](Q\d+_K_[SMLA])",
         r"[.-](Q\d+_\d+)",
         r"[.-](Q\d+_K)",
+        r"[.-](TQ\d+_\d+)",
         r"[.-](IQ\d+_\w+)",
         r"[.-](MXFP4|NVFP4)",
-        r"[.-](F16|FP16|BF16|F32)",
+        r"[.-](F16|FP16|BF16|F32|FP32)",
     ]
     upper = filename.upper()
     for pattern in patterns:
         m = re.search(pattern, upper)
         if m:
-            return m.group(1)
+            quant = m.group(1)
+            return _QUANT_ALIASES.get(quant, quant)
     return "unknown"
 
 

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -75,3 +75,67 @@ def test_extract_quant_type_parses_fp4_gguf_filenames():
 
     assert _extract_quant_type("gpt-oss-20b-MXFP4.gguf") == "MXFP4"
     assert _extract_quant_type("model.NVFP4.gguf") == "NVFP4"
+
+
+def test_extract_quant_type_canonicalizes_full_precision_aliases():
+    # llama.cpp publishes full-precision GGUFs as *-FP16/*-FP32; the byte and
+    # penalty tables key these as F16/F32, so the extractor must canonicalize.
+    from whichllm.models.fetcher import _extract_quant_type
+
+    assert _extract_quant_type("Meta-Llama-3-8B-FP16.gguf") == "F16"
+    assert _extract_quant_type("model.FP32.gguf") == "F32"
+    # Canonical spellings still pass through unchanged.
+    assert _extract_quant_type("model-F16.gguf") == "F16"
+    assert _extract_quant_type("model.BF16.gguf") == "BF16"
+
+
+def test_extract_quant_type_recognizes_ternary_gguf():
+    # BitNet-class ternary GGUFs (TQ1_0/TQ2_0) are fully priced in the tables
+    # but were previously extracted as "unknown" and dropped at fetch.
+    from whichllm.models.fetcher import _extract_quant_type
+
+    assert _extract_quant_type("BitNet-b1.58-2B-4T-TQ1_0.gguf") == "TQ1_0"
+    assert _extract_quant_type("model.TQ2_0.gguf") == "TQ2_0"
+
+
+def test_estimate_gguf_size_does_not_undersize_fp16():
+    # An FP16 GGUF must size at full precision (2.0 bytes/weight), not collapse
+    # to the Q4_K_M 0.5625 default that an unrecognized token falls back to.
+    from whichllm.models.fetcher import _estimate_gguf_size, _extract_quant_type
+
+    params = 7_000_000_000
+    quant = _extract_quant_type("model-FP16.gguf")
+    size = _estimate_gguf_size(params, quant)
+    assert size == params * 2  # 14 GB, not the ~3.94 GB default
+    assert size == _estimate_gguf_size(params, "F16")
+
+
+def test_extract_quant_type_keys_resolve_in_byte_table():
+    # Drift guard: every quant the extractor surfaces from a real GGUF filename
+    # must resolve in QUANT_BYTES_PER_WEIGHT, otherwise it is silently mis-sized
+    # by the default or dropped at fetch. Keeps the extractor and tables aligned.
+    from whichllm.data.quantization import QUANT_BYTES_PER_WEIGHT
+    from whichllm.models.fetcher import _extract_quant_type
+
+    filenames = [
+        "model-Q4_K_M.gguf",
+        "model-Q8_0.gguf",
+        "model-Q6_K.gguf",
+        "model-IQ4_NL.gguf",
+        "model-IQ3_XXS.gguf",
+        "model-TQ1_0.gguf",
+        "model-TQ2_0.gguf",
+        "model-F16.gguf",
+        "model-FP16.gguf",
+        "model-BF16.gguf",
+        "model-F32.gguf",
+        "model-FP32.gguf",
+        "model-MXFP4.gguf",
+        "model-NVFP4.gguf",
+    ]
+    for fname in filenames:
+        quant = _extract_quant_type(fname)
+        assert quant != "unknown", f"{fname} not recognized by extractor"
+        assert quant in QUANT_BYTES_PER_WEIGHT, (
+            f"{fname} -> {quant!r} missing from QUANT_BYTES_PER_WEIGHT"
+        )


### PR DESCRIPTION
## What

`_extract_quant_type()` (the GGUF-filename → quant-type parser in `models/fetcher.py`) emitted tokens that the canonical `QUANT_BYTES_PER_WEIGHT` / `QUANT_QUALITY_PENALTY` tables don't key on, so two quant families were mishandled at fetch time.

### 1. FP16 GGUFs were sized ~3.5× too small

A `*-FP16.gguf` sibling extracts to the literal `"FP16"`, but `data/quantization.py` keys full precision as `F16` (there is no `FP16` key). `_estimate_gguf_size()` does:

```python
bpw = QUANT_BYTES_PER_WEIGHT.get(quant_type.upper(), 0.5625)  # default Q4_K_M
```

so the lookup misses and falls back to the **Q4_K_M 0.5625 bytes/weight default**. A 7B FP16 GGUF is then estimated at **~3.94 GB instead of 14 GB**. Because the HF `siblings` listing carries no per-file `size`, `_estimate_gguf_size()` is the primary GGUF sizing path, so this affects essentially every FP16 GGUF — directly producing optimistic "fits" results, the opposite of what a hardware-fit advisor should do.

### 2. Ternary GGUFs were dropped entirely

`*-TQ1_0.gguf` / `*-TQ2_0.gguf` had no matching pattern in the extractor, so they returned `"unknown"` and were skipped by the `if quant == "unknown": continue` filter — even though the tables already fully price `TQ1_0` and `TQ2_0` (and list them in `QUANT_PREFERENCE_ORDER`). BitNet-class ternary builds therefore never appeared in results.

## Fix

Additive, no table or heuristic changes:

- Add a `TQ\d+_\d+` pattern to the extractor.
- Canonicalize full-precision aliases `FP16 → F16` / `FP32 → F32` to the keys the tables use (and add `FP32` to the precision alternation so the alias is reachable).
- Regression tests, including a **drift guard** (`test_extract_quant_type_keys_resolve_in_byte_table`) asserting every quant the extractor surfaces from a real GGUF filename resolves in `QUANT_BYTES_PER_WEIGHT`, so the extractor and tables can't silently diverge again.

The quality-penalty path is unchanged: `F16` already resolves to `0.0` in `QUANT_QUALITY_PENALTY`, so only the **size** estimate is corrected.

## Testing

```
uv run pytest -q     # 400 passed
uv run ruff check    # clean
```

The four new tests are red on `main` and green here. No GPU required.

## Notes

- Scope is limited to `models/fetcher.py` + tests; the separate non-GGUF (`engine/quantization.py`) `FP16`-keyed vocabulary used for repo-name inference is intentionally left untouched.
- "Does a real repo actually ship `*-FP16.gguf` / `*-TQ1_0.gguf`?" — yes; these are common llama.cpp naming conventions (full-precision conversions and BitNet ternary builds).
