### PR TITLE
fix: filter model search by parameter count instead of substring for size tokens

### DIFF
--- a/src/whichllm/cli.py
+++ b/src/whichllm/cli.py
@@ -861,6 +861,48 @@ def _load_models(refresh: bool, include_vision: bool = True):
         sys.exit(1)
 
 
+_SIZE_TOKEN_RE = re.compile(r"^(\d+(?:\.\d+)?)([bm])$", re.IGNORECASE)
+
+
+def _parse_size_tokens(
+    terms: list[str],
+) -> tuple[list[str], float | None]:
+    """Split query terms into non-size terms and an optional size in billions.
+
+    Returns (remaining_terms, size_b) where size_b is None if no size token
+    was found.  Only the first size token is used; subsequent size tokens are
+    kept as plain text terms.  Handles 'b' (billions) and 'm' (millions).
+    """
+    remaining = []
+    size_b: float | None = None
+    for t in terms:
+        m = _SIZE_TOKEN_RE.match(t)
+        if m and size_b is None:
+            value = float(m.group(1))
+            if value <= 0:
+                remaining.append(t)
+                continue
+            unit = m.group(2).lower()
+            size_b = value if unit == "b" else value / 1000.0
+        else:
+            remaining.append(t)
+    return remaining, size_b
+
+
+def _size_compatible(model: ModelInfo, size_b: float) -> bool:
+    """Check whether a model's parameter count is compatible with a query size.
+
+    Uses a tolerance band of [0.7x, 1.5x] to accommodate rounding differences
+    (e.g. a 7B query matching a model with 7.6B actual parameters) while
+    rejecting adjacent model sizes (e.g. 7B vs 4B or 12B).
+    """
+    if model.parameter_count <= 0:
+        return True
+    actual_b = model.parameter_count / 1e9
+    ratio = actual_b / size_b
+    return 0.7 <= ratio <= 1.5
+
+
 def _search_model(models: list, model_name: str):
     """Search for a model by name/ID. Returns single model or exits."""
     query_lower = model_name.lower()
@@ -870,7 +912,13 @@ def _search_model(models: list, model_name: str):
     if not matches:
         matches = [m for m in models if m.id.lower().endswith("/" + query_lower)]
     if not matches:
-        matches = [m for m in models if all(t in m.id.lower() for t in terms)]
+        text_terms, size_b = _parse_size_tokens(terms)
+        matches = [
+            m
+            for m in models
+            if all(t in m.id.lower() for t in text_terms)
+            and (size_b is None or _size_compatible(m, size_b))
+        ]
 
     if not matches:
         console.print(f"[red]No model found matching '{model_name}'.[/]")

--- a/src/whichllm/cli.py
+++ b/src/whichllm/cli.py
@@ -907,6 +907,7 @@ def _search_model(models: list, model_name: str):
     """Search for a model by name/ID. Returns single model or exits."""
     query_lower = model_name.lower()
     terms = query_lower.split()
+    size_b = None
 
     matches = [m for m in models if m.id.lower() == query_lower]
     if not matches:
@@ -935,7 +936,16 @@ def _search_model(models: list, model_name: str):
                 console.print(f"  • {m.id} ({p})")
         raise typer.Exit(code=1)
 
-    matches.sort(key=lambda m: m.downloads, reverse=True)
+    if size_b is not None:
+        matches.sort(
+            key=lambda m: (
+                0 if m.parameter_count > 0 else 1,
+                abs(m.parameter_count / 1e9 - size_b) if m.parameter_count > 0 else 0,
+                -m.downloads,
+            )
+        )
+    else:
+        matches.sort(key=lambda m: m.downloads, reverse=True)
     model = matches[0]
     if len(matches) > 1:
         console.print(f"[dim]Found {len(matches)} matches, using: {model.id}[/]")

--- a/src/whichllm/cli.py
+++ b/src/whichllm/cli.py
@@ -889,6 +889,24 @@ def _parse_size_tokens(
     return remaining, size_b
 
 
+_ID_SIZE_RE = re.compile(r"(?:^|[-_/])(\d+(?:\.\d+)?)(b|m)(?:[-_.]|$)", re.IGNORECASE)
+
+
+def _extract_id_size_b(model_id: str) -> float | None:
+    """Extract the size label from a model ID string, in billions.
+
+    Scans for patterns like '7B', '1.7B', '500M' at word boundaries in the
+    model ID.  Returns the first match converted to billions, or None.
+    """
+    for m in _ID_SIZE_RE.finditer(model_id):
+        value = float(m.group(1))
+        if value <= 0:
+            continue
+        unit = m.group(2).lower()
+        return value if unit == "b" else value / 1000.0
+    return None
+
+
 def _size_compatible(model: ModelInfo, size_b: float) -> bool:
     """Check whether a model's parameter count is compatible with a query size.
 
@@ -937,13 +955,24 @@ def _search_model(models: list, model_name: str):
         raise typer.Exit(code=1)
 
     if size_b is not None:
-        matches.sort(
-            key=lambda m: (
-                0 if m.parameter_count > 0 else 1,
-                abs(m.parameter_count / 1e9 - size_b) if m.parameter_count > 0 else 0,
+
+        def _sort_key(m: ModelInfo) -> tuple:
+            id_size = _extract_id_size_b(m.id)
+            has_id_size = id_size is not None
+            id_dist = abs(id_size - size_b) if has_id_size else float("inf")
+            pc_dist = (
+                abs(m.parameter_count / 1e9 - size_b)
+                if m.parameter_count > 0
+                else float("inf")
+            )
+            return (
+                0 if (has_id_size or m.parameter_count > 0) else 1,
+                id_dist,
+                pc_dist,
                 -m.downloads,
             )
-        )
+
+        matches.sort(key=_sort_key)
     else:
         matches.sort(key=lambda m: m.downloads, reverse=True)
     model = matches[0]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -557,12 +557,12 @@ def test_plan_display_plan_json_outputs_valid_json():
 # --------------- helper tests ---------------
 
 
-def _make_model(model_id="org/Test-7B-GGUF", downloads=100, gguf_variants=None):
+def _make_model(model_id="org/Test-7B-GGUF", downloads=100, gguf_variants=None, parameter_count=7_000_000_000):
     return ModelInfo(
         id=model_id,
         family_id="test-7b",
         name="Test-7B",
-        parameter_count=7_000_000_000,
+        parameter_count=parameter_count,
         downloads=downloads,
         likes=10,
         gguf_variants=gguf_variants or [],
@@ -591,6 +591,89 @@ def test_search_model_not_found():
     models = [_make_model("org/Llama-8B")]
     with pytest.raises(Exit):
         _search_model(models, "nonexistent_xyz")
+
+
+# --- regression tests for size-token substring matching (#107) ---
+
+
+def test_search_model_7b_does_not_match_1_7b():
+    """'qwen 7b' should NOT match Qwen3-1.7B (issue #107)."""
+    models = [
+        _make_model("org/Qwen3-1.7B-GGUF", downloads=9999, parameter_count=1_700_000_000),
+        _make_model("org/Qwen3-7B-GGUF", downloads=100, parameter_count=7_000_000_000),
+    ]
+    result = _search_model(models, "qwen 7b")
+    assert result.id == "org/Qwen3-7B-GGUF"
+
+
+def test_search_model_2b_does_not_match_12b():
+    """'gemma 2b' should NOT match gemma-3-12b-it (issue #107)."""
+    models = [
+        _make_model("google/gemma-3-12b-it", downloads=5000, parameter_count=12_000_000_000),
+        _make_model("google/gemma-2b", downloads=100, parameter_count=2_000_000_000),
+    ]
+    result = _search_model(models, "gemma 2b")
+    assert result.id == "google/gemma-2b"
+
+
+def test_search_model_3b_does_not_match_30b_a3b():
+    """'qwen 3b' should NOT match Qwen3-30B-A3B (issue #107)."""
+    models = [
+        _make_model("org/Qwen3-30B-A3B-GGUF", downloads=8000, parameter_count=30_000_000_000),
+        _make_model("org/Qwen3-3B-GGUF", downloads=50, parameter_count=3_000_000_000),
+    ]
+    result = _search_model(models, "qwen 3b")
+    assert result.id == "org/Qwen3-3B-GGUF"
+
+
+def test_search_model_no_size_token_still_works():
+    """Queries without a size token should still use plain substring matching."""
+    models = [
+        _make_model("org/Llama-3.1-8B-GGUF", parameter_count=8_000_000_000),
+        _make_model("org/Qwen-7B", parameter_count=7_000_000_000),
+    ]
+    result = _search_model(models, "llama gguf")
+    assert result.id == "org/Llama-3.1-8B-GGUF"
+
+
+def test_search_model_millions_size_token():
+    """'500m' size token should match a ~500M parameter model."""
+    models = [
+        _make_model("org/SmolLM-500M", downloads=200, parameter_count=500_000_000),
+        _make_model("org/SmolLM-1.7B", downloads=300, parameter_count=1_700_000_000),
+    ]
+    result = _search_model(models, "smollm 500m")
+    assert result.id == "org/SmolLM-500M"
+
+
+def test_search_model_decimal_size_token():
+    """'0.5b' size token should match a ~500M parameter model."""
+    models = [
+        _make_model("org/TinyModel-0.5B", downloads=100, parameter_count=500_000_000),
+        _make_model("org/TinyModel-3B", downloads=500, parameter_count=3_000_000_000),
+    ]
+    result = _search_model(models, "tinymodel 0.5b")
+    assert result.id == "org/TinyModel-0.5B"
+
+
+def test_search_model_zero_param_count_passes_through():
+    """Models with parameter_count=0 (missing metadata) should not be excluded."""
+    models = [
+        _make_model("org/Mystery-7B-GGUF", downloads=500, parameter_count=0),
+    ]
+    result = _search_model(models, "mystery 7b")
+    assert result.id == "org/Mystery-7B-GGUF"
+
+
+def test_search_model_first_size_token_wins():
+    """When multiple size tokens appear, only the first is used as a filter."""
+    models = [
+        _make_model("org/Qwen3-30B-A3B-GGUF", downloads=8000, parameter_count=30_000_000_000),
+        _make_model("org/Qwen3-7B-3B-GGUF", downloads=100, parameter_count=7_000_000_000),
+    ]
+    # "7b" is the first size token and filters by ~7B; "3b" becomes a text term
+    result = _search_model(models, "qwen 7b 3b")
+    assert result.id == "org/Qwen3-7B-3B-GGUF"
 
 
 def test_pick_gguf_variant_by_preference():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -557,7 +557,12 @@ def test_plan_display_plan_json_outputs_valid_json():
 # --------------- helper tests ---------------
 
 
-def _make_model(model_id="org/Test-7B-GGUF", downloads=100, gguf_variants=None, parameter_count=7_000_000_000):
+def _make_model(
+    model_id="org/Test-7B-GGUF",
+    downloads=100,
+    gguf_variants=None,
+    parameter_count=7_000_000_000,
+):
     return ModelInfo(
         id=model_id,
         family_id="test-7b",
@@ -599,7 +604,9 @@ def test_search_model_not_found():
 def test_search_model_7b_does_not_match_1_7b():
     """'qwen 7b' should NOT match Qwen3-1.7B (issue #107)."""
     models = [
-        _make_model("org/Qwen3-1.7B-GGUF", downloads=9999, parameter_count=1_700_000_000),
+        _make_model(
+            "org/Qwen3-1.7B-GGUF", downloads=9999, parameter_count=1_700_000_000
+        ),
         _make_model("org/Qwen3-7B-GGUF", downloads=100, parameter_count=7_000_000_000),
     ]
     result = _search_model(models, "qwen 7b")
@@ -609,7 +616,9 @@ def test_search_model_7b_does_not_match_1_7b():
 def test_search_model_2b_does_not_match_12b():
     """'gemma 2b' should NOT match gemma-3-12b-it (issue #107)."""
     models = [
-        _make_model("google/gemma-3-12b-it", downloads=5000, parameter_count=12_000_000_000),
+        _make_model(
+            "google/gemma-3-12b-it", downloads=5000, parameter_count=12_000_000_000
+        ),
         _make_model("google/gemma-2b", downloads=100, parameter_count=2_000_000_000),
     ]
     result = _search_model(models, "gemma 2b")
@@ -619,7 +628,9 @@ def test_search_model_2b_does_not_match_12b():
 def test_search_model_3b_does_not_match_30b_a3b():
     """'qwen 3b' should NOT match Qwen3-30B-A3B (issue #107)."""
     models = [
-        _make_model("org/Qwen3-30B-A3B-GGUF", downloads=8000, parameter_count=30_000_000_000),
+        _make_model(
+            "org/Qwen3-30B-A3B-GGUF", downloads=8000, parameter_count=30_000_000_000
+        ),
         _make_model("org/Qwen3-3B-GGUF", downloads=50, parameter_count=3_000_000_000),
     ]
     result = _search_model(models, "qwen 3b")
@@ -668,8 +679,12 @@ def test_search_model_zero_param_count_passes_through():
 def test_search_model_first_size_token_wins():
     """When multiple size tokens appear, only the first is used as a filter."""
     models = [
-        _make_model("org/Qwen3-30B-A3B-GGUF", downloads=8000, parameter_count=30_000_000_000),
-        _make_model("org/Qwen3-7B-3B-GGUF", downloads=100, parameter_count=7_000_000_000),
+        _make_model(
+            "org/Qwen3-30B-A3B-GGUF", downloads=8000, parameter_count=30_000_000_000
+        ),
+        _make_model(
+            "org/Qwen3-7B-3B-GGUF", downloads=100, parameter_count=7_000_000_000
+        ),
     ]
     # "7b" is the first size token and filters by ~7B; "3b" becomes a text term
     result = _search_model(models, "qwen 7b 3b")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -691,6 +691,50 @@ def test_search_model_first_size_token_wins():
     assert result.id == "org/Qwen3-7B-3B-GGUF"
 
 
+def test_search_model_7b_prefers_closest_size_over_downloads():
+    """'qwen 7b' should pick 8B (closest to 7B) over 4B even if 4B has more downloads."""
+    models = [
+        _make_model("org/Qwen3-4B-GGUF", downloads=9000, parameter_count=4_000_000_000),
+        _make_model("org/Qwen3-8B-GGUF", downloads=100, parameter_count=8_000_000_000),
+    ]
+    result = _search_model(models, "qwen 7b")
+    assert result.id == "org/Qwen3-8B-GGUF"
+
+
+def test_search_model_3b_prefers_closest_size_over_downloads():
+    """'qwen 3b' should pick 3B (exact) over 4B even if 4B has more downloads."""
+    models = [
+        _make_model("org/Qwen3-4B-GGUF", downloads=9000, parameter_count=4_000_000_000),
+        _make_model("org/Qwen3-3B-GGUF", downloads=50, parameter_count=3_000_000_000),
+    ]
+    result = _search_model(models, "qwen 3b")
+    assert result.id == "org/Qwen3-3B-GGUF"
+
+
+def test_search_model_size_tiebreak_falls_back_to_downloads():
+    """When two models are equally close in size, prefer the one with more downloads."""
+    models = [
+        _make_model(
+            "org/Qwen3-8B-A-GGUF", downloads=100, parameter_count=8_000_000_000
+        ),
+        _make_model(
+            "org/Qwen3-8B-B-GGUF", downloads=500, parameter_count=8_000_000_000
+        ),
+    ]
+    result = _search_model(models, "qwen 7b")
+    assert result.id == "org/Qwen3-8B-B-GGUF"
+
+
+def test_search_model_unknown_param_count_ranks_after_known():
+    """Models with parameter_count=0 should rank after models with known sizes."""
+    models = [
+        _make_model("org/Qwen3-Unknown-GGUF", downloads=9999, parameter_count=0),
+        _make_model("org/Qwen3-7B-GGUF", downloads=10, parameter_count=7_000_000_000),
+    ]
+    result = _search_model(models, "qwen 7b")
+    assert result.id == "org/Qwen3-7B-GGUF"
+
+
 def test_pick_gguf_variant_by_preference():
     variants = [
         GGUFVariant(filename="q2.gguf", quant_type="Q2_K", file_size_bytes=1000),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,7 @@ from whichllm.cli import (
     _apply_memory_budgets,
     _apply_gpu_overrides,
     _auto_min_params_for_profile,
+    _extract_id_size_b,
     _fill_missing_published_at,
     _format_fetch_error,
     _generate_chat_script,
@@ -733,6 +734,34 @@ def test_search_model_unknown_param_count_ranks_after_known():
     ]
     result = _search_model(models, "qwen 7b")
     assert result.id == "org/Qwen3-7B-GGUF"
+
+
+@pytest.mark.parametrize(
+    "model_id, expected",
+    [
+        ("org/Qwen3-8B-GGUF", 8.0),
+        ("org/Qwen3.5-9B-NVFP4", 9.0),
+        ("org/Qwen3-30B-A3B-GGUF", 30.0),
+        ("org/SmolLM-500M", 0.5),
+        ("org/TinyModel-1.7B-Chat", 1.7),
+        ("org/Llama-3.1-8B-Instruct", 8.0),
+        ("org/NoSizeLabel-GGUF", None),
+    ],
+)
+def test_extract_id_size_b(model_id, expected):
+    assert _extract_id_size_b(model_id) == expected
+
+
+def test_search_model_7b_prefers_id_label_over_param_count():
+    """'qwen 7b' should not pick a 9B-labeled repo even if its param count is closer."""
+    models = [
+        _make_model(
+            "org/Qwen3.5-9B-NVFP4", downloads=500, parameter_count=6_600_000_000
+        ),
+        _make_model("org/Qwen3-8B-GGUF", downloads=100, parameter_count=8_000_000_000),
+    ]
+    result = _search_model(models, "qwen 7b")
+    assert result.id == "org/Qwen3-8B-GGUF"
 
 
 def test_pick_gguf_variant_by_preference():


### PR DESCRIPTION
## Summary

Fixes #107. `_search_model` used plain substring matching (`"7b" in model_id`), so querying `"qwen 7b"` could match `Qwen3-1.7B` or `Qwen3-27B` depending on download count.

Size tokens (e.g. `7b`, `0.5b`, `500m`) are now parsed out of the query and matched against `parameter_count` with a [0.7x, 1.5x] tolerance band, same approach the rest of the engine uses (`_has_compatible_parameter_count`, `_params_compatible`). Non-size terms still use substring matching.

## Changes

- `_parse_size_tokens()` splits query into text terms and an optional numeric size
- `_size_compatible()` checks `parameter_count` falls within tolerance of queried size
- 8 regression tests covering 7b/1.7b, 2b/12b, 3b/30B-A3B, millions, decimals, missing metadata, multiple size tokens

## Test plan

- [x] `uv run pytest` passes (404/404)
- [ ] Manual: `whichllm snippet "qwen 7b gguf"` returns a 7B model, not 1.7B
- [ ] Manual: `whichllm plan "gemma 2b"` returns a 2B model, not 12B