### PR TITLE
Support HF_ENDPOINT for Hugging Face model metadata

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -39,6 +39,12 @@ Common options:
 | `--ram-budget` | Cap RAM available for partial offload. Accepts `available`, byte values like `8GB`, or percentages like `50%` |
 | `--version` | Print the installed package version |
 
+Environment variables:
+
+| Variable | Meaning |
+| --- | --- |
+| `HF_ENDPOINT` | Hugging Face endpoint root used for whichllm's own model metadata API calls. Example: `https://huggingface.co` or a compatible mirror root |
+
 `--fit any` is the default. It can include full-GPU, partial-offload, and
 CPU-only candidates when they are runnable. `--fit gpu`, `--fit full-gpu`, and
 `--gpu-only` keep only rows whose `fit_type` is `full_gpu`.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -330,6 +330,23 @@ Try a known public GGUF model first:
 whichllm run "qwen 2.5 1.5b gguf"
 ```
 
+## Hugging Face API access fails or needs a mirror
+
+whichllm uses the Hugging Face API to fetch model metadata. If direct access to
+`huggingface.co` fails in your network, set `HF_ENDPOINT` to a compatible
+endpoint root:
+
+```powershell
+$env:HF_ENDPOINT = "https://huggingface.co"
+whichllm --refresh
+```
+
+```bash
+HF_ENDPOINT="https://huggingface.co" whichllm --refresh
+```
+
+Do not include `/api` in `HF_ENDPOINT`; whichllm adds that path internally.
+
 ## How much disk space does `run` need?
 
 Normal ranking commands do not download model weights. They cache Hugging Face

--- a/src/whichllm/models/fetcher.py
+++ b/src/whichllm/models/fetcher.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import re
 import statistics
 
@@ -15,7 +16,7 @@ from whichllm.models.types import GGUFVariant, ModelInfo
 
 logger = logging.getLogger(__name__)
 
-HF_API_BASE = "https://huggingface.co/api"
+_DEFAULT_HF_ENDPOINT = "https://huggingface.co"
 _GGUF_SPLIT_RE = re.compile(r"-(\d{5})-of-(\d{5})\.gguf$", re.IGNORECASE)
 _GENERAL_EVAL_KEYWORDS = (
     "mmlu",
@@ -29,6 +30,17 @@ _GENERAL_EVAL_KEYWORDS = (
     "ceval",
     "cmmlu",
 )
+
+
+def _hf_api_url(path: str) -> str:
+    raw_endpoint = os.environ.get("HF_ENDPOINT")
+    endpoint = _DEFAULT_HF_ENDPOINT if raw_endpoint is None else raw_endpoint.strip()
+    if not endpoint:
+        raise ValueError("HF_ENDPOINT must not be empty")
+    if not endpoint.startswith(("http://", "https://")):
+        raise ValueError("HF_ENDPOINT must start with http:// or https://")
+    endpoint = endpoint.rstrip("/")
+    return f"{endpoint}/api/{path.lstrip('/')}"
 
 
 def _extract_published_at(data: dict) -> str | None:
@@ -595,7 +607,7 @@ async def fetch_models(
             ],
         }
         logger.debug(f"Fetching models from HF API (limit={limit})")
-        resp = await get_with_retries(client, f"{HF_API_BASE}/models", params=params)
+        resp = await get_with_retries(client, _hf_api_url("models"), params=params)
         resp.raise_for_status()
         data_list = resp.json()
         for data in data_list:
@@ -619,9 +631,7 @@ async def fetch_models(
             ],
         }
         logger.debug("Fetching GGUF models from HF API")
-        resp = await get_with_retries(
-            client, f"{HF_API_BASE}/models", params=gguf_params
-        )
+        resp = await get_with_retries(client, _hf_api_url("models"), params=gguf_params)
         resp.raise_for_status()
         gguf_data_list = resp.json()
 
@@ -650,7 +660,7 @@ async def fetch_models(
         }
         logger.debug("Fetching recent GGUF models from HF API")
         resp = await get_with_retries(
-            client, f"{HF_API_BASE}/models", params=recent_params
+            client, _hf_api_url("models"), params=recent_params
         )
         resp.raise_for_status()
         recent_data_list = resp.json()
@@ -686,7 +696,7 @@ async def fetch_models(
             )
             try:
                 resp = await get_with_retries(
-                    client, f"{HF_API_BASE}/models", params=trending_params
+                    client, _hf_api_url("models"), params=trending_params
                 )
                 resp.raise_for_status()
                 trending_data_list = resp.json()
@@ -785,7 +795,7 @@ async def fetch_models(
             try:
                 resp = await get_with_retries(
                     client,
-                    f"{HF_API_BASE}/models/{model_id}",
+                    _hf_api_url(f"models/{model_id}"),
                     params={
                         "expand[]": [
                             "config",
@@ -833,7 +843,7 @@ async def fetch_models(
                 }
                 logger.debug(f"Fetching {pipeline_tag} models from HF API")
                 resp = await get_with_retries(
-                    client, f"{HF_API_BASE}/models", params=mm_params
+                    client, _hf_api_url("models"), params=mm_params
                 )
                 resp.raise_for_status()
                 mm_data_list = resp.json()
@@ -939,7 +949,7 @@ async def fetch_model_published_at(model_ids: list[str]) -> dict[str, str]:
     async with httpx.AsyncClient(timeout=20.0, follow_redirects=True) as client:
         tasks = [
             client.get(
-                f"{HF_API_BASE}/models/{model_id}",
+                _hf_api_url(f"models/{model_id}"),
                 params={"expand[]": ["createdAt", "lastModified"]},
             )
             for model_id in unique_ids

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -1,14 +1,104 @@
 """Tests for model metadata normalization in fetcher."""
 
+import asyncio
+
+import httpx
+
+import whichllm.models.fetcher as fetcher
 from whichllm.models.fetcher import (
     _extract_hf_eval_score,
     _extract_published_at,
+    _hf_api_url,
     _normalize_param_count,
     _parse_model,
     dicts_to_models,
     models_to_dicts,
 )
 from whichllm.models.types import ModelInfo
+
+
+def test_hf_api_url_uses_default_endpoint(monkeypatch):
+    monkeypatch.delenv("HF_ENDPOINT", raising=False)
+
+    assert _hf_api_url("models") == "https://huggingface.co/api/models"
+
+
+def test_hf_api_url_respects_hf_endpoint(monkeypatch):
+    monkeypatch.setenv("HF_ENDPOINT", "https://hf-mirror.example")
+
+    assert _hf_api_url("models/Qwen/Qwen3-8B") == (
+        "https://hf-mirror.example/api/models/Qwen/Qwen3-8B"
+    )
+
+
+def test_hf_api_url_strips_trailing_slash(monkeypatch):
+    monkeypatch.setenv("HF_ENDPOINT", "https://hf-mirror.example/")
+
+    assert _hf_api_url("/models") == "https://hf-mirror.example/api/models"
+
+
+def test_hf_api_url_rejects_empty_endpoint(monkeypatch):
+    monkeypatch.setenv("HF_ENDPOINT", " ")
+
+    try:
+        _hf_api_url("models")
+    except ValueError as exc:
+        assert "HF_ENDPOINT must not be empty" in str(exc)
+    else:
+        raise AssertionError("expected empty HF_ENDPOINT to raise")
+
+
+def test_hf_api_url_rejects_endpoint_without_scheme(monkeypatch):
+    monkeypatch.setenv("HF_ENDPOINT", "hf-mirror.example")
+
+    try:
+        _hf_api_url("models")
+    except ValueError as exc:
+        assert "HF_ENDPOINT must start with http:// or https://" in str(exc)
+    else:
+        raise AssertionError("expected invalid HF_ENDPOINT to raise")
+
+
+def test_fetch_models_respects_hf_endpoint(monkeypatch):
+    monkeypatch.setenv("HF_ENDPOINT", "https://hf-mirror.example")
+    urls: list[str] = []
+
+    async def fake_get_with_retries(client, url: str, **kwargs):
+        urls.append(url)
+        request = httpx.Request("GET", url)
+        if "/models/" in url:
+            return httpx.Response(404, request=request)
+        return httpx.Response(200, json=[], request=request)
+
+    monkeypatch.setattr(fetcher, "get_with_retries", fake_get_with_retries)
+
+    models = asyncio.run(fetcher.fetch_models(limit=1, include_vision=False))
+
+    assert models == []
+    assert urls
+    assert all(url.startswith("https://hf-mirror.example/api/") for url in urls)
+    assert "https://hf-mirror.example/api/models" in urls
+    assert not any(url.startswith("https://huggingface.co/api/") for url in urls)
+
+
+def test_fetch_model_published_at_respects_hf_endpoint(monkeypatch):
+    monkeypatch.setenv("HF_ENDPOINT", "https://hf-mirror.example")
+    urls: list[str] = []
+
+    async def fake_get(self, url: str, **kwargs):
+        urls.append(url)
+        return httpx.Response(
+            200,
+            json={"createdAt": "2026-06-22T00:00:00.000Z"},
+            request=httpx.Request("GET", url),
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+
+    result = asyncio.run(fetcher.fetch_model_published_at(["Qwen/Qwen3-8B"]))
+
+    assert result == {"Qwen/Qwen3-8B": "2026-06-22T00:00:00.000Z"}
+    assert urls == ["https://hf-mirror.example/api/models/Qwen/Qwen3-8B"]
 
 
 def test_normalize_param_count_for_quantized_repo_uses_size_hint():


### PR DESCRIPTION
## Summary

This adds `HF_ENDPOINT` support for whichllm's own Hugging Face model metadata API calls.

The change is intentionally small. It only affects the model fetch path in `models/fetcher.py`. dataset-server URLs are left alone for now.

## Notes

- `HF_ENDPOINT` should be an endpoint root, for example `https://huggingface.co` or a compatible mirror root.
- whichllm appends `/api` internally.
- Empty values and endpoints without `http://` or `https://` are rejected.

## Checks

Local lint, focused tests, full tests, compile, and endpoint URL sanity checks passed.