### PR TITLE
Igpu hardware overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ whichllm
 # Pretend you have a specific GPU
 whichllm --gpu "RTX 4090"
 
+# Override detected iGPU/unified-memory limits
+whichllm --vram 8 --ram-bandwidth 68
+
 # Only show models that fit fully in GPU VRAM
 whichllm --gpu-only
 whichllm --fit gpu
@@ -232,6 +235,8 @@ whichllm --gpu "RTX 4090"
 whichllm --gpu "RTX 5090"
 # Specify variant
 whichllm --gpu "RTX 5060 16"
+# Override detected iGPU/unified-memory limits
+whichllm --vram 8 --ram-bandwidth 68
 # Simulate multiple GPUs
 whichllm --gpu "2x RTX 4090"
 whichllm --gpu "RTX 4090" --gpu "RTX 3090"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -34,7 +34,9 @@ Common options:
 | `--refresh` | Ignore caches and fetch models/benchmarks again |
 | `--cpu-only` | Ignore GPUs and rank for CPU-only use |
 | `--gpu` | Simulate GPU(s) by name. Accepts repeated flags, comma-separated values, and count shorthand |
-| `--vram` | Override simulated GPU VRAM in GB. Requires `--gpu` |
+| `--vram` | Override simulated GPU VRAM or detected GPU usable VRAM in GB |
+| `--bandwidth`, `--ram-bandwidth` | Override GPU/RAM bandwidth in GB/s |
+| `--gpu-index` | Detected GPU index to override when multiple GPUs are present |
 | `--vram-headroom` | Reserve per-GPU memory for runtime overhead. Default: `auto`. Accepts `none`, byte values like `1.5GB`, or percentages like `10%` |
 | `--ram-budget` | Cap RAM available for partial offload. Accepts `available`, byte values like `8GB`, or percentages like `50%` |
 | `--version` | Print the installed package version |
@@ -59,6 +61,10 @@ and `?` markers still refer to estimate confidence, not speed quality.
 checks, so near-edge recommendations are less likely to overflow in tools such
 as LM Studio. Use `--vram-headroom none` to restore the raw detected VRAM.
 `--ram-budget available` caps offload planning to current available RAM.
+For detected iGPU or unified-memory systems, use `--vram` and
+`--bandwidth` / `--ram-bandwidth` to override the automatically detected
+usable memory and bandwidth. If multiple GPUs are detected, add `--gpu-index`
+with the GPU number from `whichllm hardware`.
 
 Examples:
 
@@ -66,6 +72,8 @@ Examples:
 whichllm
 whichllm --gpu "RTX 4090"
 whichllm --gpu "RTX 5060 Ti" --vram 16
+whichllm --vram 8 --ram-bandwidth 68
+whichllm --gpu-index 1 --vram 8 --bandwidth 68
 whichllm --gpu "2x RTX 4090"
 whichllm --gpu "RTX 4090" --gpu "RTX 3090"
 whichllm --gpu "RTX 4090, RTX 3090"
@@ -121,6 +129,7 @@ whichllm hardware
 whichllm hardware --cpu-only
 whichllm hardware --gpu "Apple M3 Max"
 whichllm hardware --gpu "RTX 3060" --vram 12
+whichllm hardware --vram 8 --bandwidth 68
 whichllm hardware --gpu "4x RTX 4090"
 ```
 

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -143,7 +143,21 @@ whichllm --gpu "RTX 5060 Ti" --vram 16
 whichllm hardware --gpu "Unknown GPU" --vram 24
 ```
 
-`--vram` requires `--gpu`.
+For detected integrated or unified-memory GPUs, use `--vram` and
+`--bandwidth` / `--ram-bandwidth` to override the automatically detected usable
+capacity and memory bandwidth:
+
+```bash
+whichllm --vram 8 --ram-bandwidth 68
+whichllm hardware --vram 8 --bandwidth 68
+```
+
+If multiple GPUs are detected, pass `--gpu-index` to choose the GPU shown by
+`whichllm hardware`:
+
+```bash
+whichllm --gpu-index 1 --vram 8 --ram-bandwidth 68
+```
 
 By default, whichllm applies a small automatic VRAM headroom before fit checks.
 This avoids recommending models that only fit on paper but overflow in runtimes

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -48,8 +48,19 @@ whichllm --gpu "RTX 4090" --gpu "RTX 3090"
 Use `--vram` when the GPU name has multiple memory variants or is not in the
 database.
 
-`--vram` only applies to a single simulated GPU. For multi-GPU simulation, use
-known GPU names and omit `--vram`.
+For detected iGPU or unified-memory systems, override the usable GPU memory and
+bandwidth directly:
+
+```bash
+whichllm hardware --vram 8 --ram-bandwidth 68
+whichllm --vram 8 --bandwidth 68
+```
+
+If `whichllm hardware` lists multiple GPUs, add `--gpu-index` with the GPU
+number from that output.
+
+`--vram` only applies to one simulated or detected GPU. For multi-GPU
+simulation, use known GPU names and omit `--vram`.
 
 ## `--cpu-only` conflicts with `--gpu`
 
@@ -66,16 +77,17 @@ whichllm --cpu-only
 whichllm --gpu "RTX 4090"
 ```
 
-## `--vram` requires `--gpu`
+## `--vram` / `--bandwidth` needs a GPU
 
-`--vram` is an override for a simulated GPU. It does not change detected
-hardware by itself.
-
-Use:
+These overrides need either a detected GPU or a simulated GPU:
 
 ```bash
+whichllm --vram 8 --ram-bandwidth 68
 whichllm --gpu "RTX 3060" --vram 12
 ```
+
+If no GPU is detected, use `--gpu` to simulate one or check the detection steps
+above.
 
 ## No compatible models found
 

--- a/src/whichllm/cli.py
+++ b/src/whichllm/cli.py
@@ -57,13 +57,32 @@ def _validate_gpu_flags(
     cpu_only: bool,
     gpu: list[str] | None,
     vram: float | None,
+    bandwidth: float | None = None,
+    gpu_index: int | None = None,
 ) -> None:
     """Validate mutual exclusivity of GPU-related flags."""
     if cpu_only and gpu:
         console.print("[red]Error:[/] --cpu-only and --gpu are mutually exclusive.")
         raise typer.Exit(code=1)
-    if vram is not None and not gpu:
-        console.print("[red]Error:[/] --vram requires --gpu.")
+    if cpu_only and (vram is not None or bandwidth is not None):
+        console.print(
+            "[red]Error:[/] --cpu-only cannot be used with GPU overrides."
+        )
+        raise typer.Exit(code=1)
+    if vram is not None and vram <= 0:
+        console.print("[red]Error:[/] --vram must be greater than 0.")
+        raise typer.Exit(code=1)
+    if bandwidth is not None and bandwidth <= 0:
+        console.print("[red]Error:[/] --bandwidth must be greater than 0.")
+        raise typer.Exit(code=1)
+    if gpu_index is not None and gpu_index < 0:
+        console.print("[red]Error:[/] --gpu-index must be 0 or greater.")
+        raise typer.Exit(code=1)
+    if gpu_index is not None and gpu:
+        console.print("[red]Error:[/] --gpu-index only applies to detected GPUs.")
+        raise typer.Exit(code=1)
+    if gpu_index is not None and vram is None and bandwidth is None:
+        console.print("[red]Error:[/] --gpu-index requires --vram or --bandwidth.")
         raise typer.Exit(code=1)
 
 
@@ -262,6 +281,8 @@ def _apply_gpu_overrides(
     cpu_only: bool,
     gpu: list[str] | None,
     vram: float | None,
+    bandwidth: float | None = None,
+    gpu_index: int | None = None,
 ) -> HardwareInfo:
     """Replace hardware.gpus based on CLI flags."""
     if cpu_only:
@@ -274,6 +295,43 @@ def _apply_gpu_overrides(
         except ValueError as e:
             console.print(f"[red]Error:[/] {e}")
             raise typer.Exit(code=1)
+        if bandwidth is not None:
+            if len(hardware.gpus) != 1:
+                console.print(
+                    "[red]Error:[/] --bandwidth currently supports exactly one "
+                    "simulated GPU."
+                )
+                raise typer.Exit(code=1)
+            hardware.gpus[0].memory_bandwidth_gbps = bandwidth
+    elif vram is not None or bandwidth is not None:
+        if not hardware.gpus:
+            console.print(
+                "[red]Error:[/] --vram/--bandwidth requires a detected GPU or --gpu."
+            )
+            raise typer.Exit(code=1)
+        if gpu_index is None:
+            if len(hardware.gpus) > 1:
+                console.print(
+                    "[red]Error:[/] --gpu-index is required when overriding "
+                    "detected hardware with multiple GPUs."
+                )
+                raise typer.Exit(code=1)
+            target_gpu = hardware.gpus[0]
+        else:
+            if gpu_index >= len(hardware.gpus):
+                console.print(
+                    f"[red]Error:[/] --gpu-index {gpu_index} is out of range "
+                    f"for {len(hardware.gpus)} detected GPU(s)."
+                )
+                raise typer.Exit(code=1)
+            target_gpu = hardware.gpus[gpu_index]
+
+        if vram is not None:
+            target_gpu.vram_bytes = int(vram * _GiB)
+            target_gpu.usable_vram_bytes = None
+            target_gpu.vram_overridden = True
+        if bandwidth is not None:
+            target_gpu.memory_bandwidth_gbps = bandwidth
     return hardware
 
 
@@ -451,7 +509,20 @@ def main(
         help="Simulate GPU(s), e.g. 'RTX 4090', '2x RTX 4090', or repeat --gpu",
     ),
     vram: Optional[float] = typer.Option(
-        None, "--vram", help="Override VRAM in GB (requires --gpu)"
+        None,
+        "--vram",
+        help="Override simulated GPU VRAM or detected GPU usable VRAM in GB",
+    ),
+    bandwidth: Optional[float] = typer.Option(
+        None,
+        "--bandwidth",
+        "--ram-bandwidth",
+        help="Override GPU/RAM bandwidth in GB/s",
+    ),
+    gpu_index: Optional[int] = typer.Option(
+        None,
+        "--gpu-index",
+        help="Detected GPU index to override when multiple GPUs are present",
     ),
     vram_headroom: str = typer.Option(
         "auto",
@@ -468,7 +539,7 @@ def main(
     if ctx.invoked_subcommand is not None:
         return
 
-    _validate_gpu_flags(cpu_only, gpu, vram)
+    _validate_gpu_flags(cpu_only, gpu, vram, bandwidth, gpu_index)
     _validate_output_flags(json_output, markdown_output)
     profile = _validate_profile(profile)
     evidence_mode = _resolve_evidence_mode(evidence, direct)
@@ -508,7 +579,7 @@ def main(
         # Step 1: Detect hardware
         task = progress.add_task("Detecting hardware...", total=None)
         hardware = detect_hardware()
-        _apply_gpu_overrides(hardware, cpu_only, gpu, vram)
+        _apply_gpu_overrides(hardware, cpu_only, gpu, vram, bandwidth, gpu_index)
         _apply_memory_budgets(
             hardware, vram_headroom=vram_headroom, ram_budget=ram_budget
         )
@@ -1345,11 +1416,24 @@ def hardware(
         help="Simulate GPU(s), e.g. 'RTX 4090', '2x RTX 4090', or repeat --gpu",
     ),
     vram: Optional[float] = typer.Option(
-        None, "--vram", help="Override VRAM in GB (requires --gpu)"
+        None,
+        "--vram",
+        help="Override simulated GPU VRAM or detected GPU usable VRAM in GB",
+    ),
+    bandwidth: Optional[float] = typer.Option(
+        None,
+        "--bandwidth",
+        "--ram-bandwidth",
+        help="Override GPU/RAM bandwidth in GB/s",
+    ),
+    gpu_index: Optional[int] = typer.Option(
+        None,
+        "--gpu-index",
+        help="Detected GPU index to override when multiple GPUs are present",
     ),
 ):
     """Show detected hardware information only."""
-    _validate_gpu_flags(cpu_only, gpu, vram)
+    _validate_gpu_flags(cpu_only, gpu, vram, bandwidth, gpu_index)
 
     from rich.progress import Progress, SpinnerColumn, TextColumn
 
@@ -1364,7 +1448,7 @@ def hardware(
     ) as progress:
         task = progress.add_task("Detecting hardware...", total=None)
         hw = detect_hardware()
-        _apply_gpu_overrides(hw, cpu_only, gpu, vram)
+        _apply_gpu_overrides(hw, cpu_only, gpu, vram, bandwidth, gpu_index)
         progress.remove_task(task)
 
     console.print()

--- a/src/whichllm/cli.py
+++ b/src/whichllm/cli.py
@@ -65,9 +65,7 @@ def _validate_gpu_flags(
         console.print("[red]Error:[/] --cpu-only and --gpu are mutually exclusive.")
         raise typer.Exit(code=1)
     if cpu_only and (vram is not None or bandwidth is not None):
-        console.print(
-            "[red]Error:[/] --cpu-only cannot be used with GPU overrides."
-        )
+        console.print("[red]Error:[/] --cpu-only cannot be used with GPU overrides.")
         raise typer.Exit(code=1)
     if vram is not None and vram <= 0:
         console.print("[red]Error:[/] --vram must be greater than 0.")

--- a/src/whichllm/engine/compatibility.py
+++ b/src/whichllm/engine/compatibility.py
@@ -23,7 +23,7 @@ def _gpu_available_memory(
     vram_bytes = (
         gpu.usable_vram_bytes if gpu.usable_vram_bytes is not None else gpu.vram_bytes
     )
-    if gpu.shared_memory and vram_bytes < 2 * _GiB:
+    if gpu.shared_memory and vram_bytes < 2 * _GiB and not gpu.vram_overridden:
         return usable_ram
     if gpu.shared_memory and ram_budget_active:
         return min(vram_bytes, usable_ram)
@@ -31,7 +31,7 @@ def _gpu_available_memory(
 
 
 def _uses_shared_system_pool(gpu: GPUInfo) -> bool:
-    return gpu.shared_memory and gpu.vram_bytes < 2 * _GiB
+    return gpu.shared_memory and gpu.vram_bytes < 2 * _GiB and not gpu.vram_overridden
 
 
 def _is_vulkan_only_gpu(gpu: GPUInfo) -> bool:

--- a/src/whichllm/hardware/gpu_simulator.py
+++ b/src/whichllm/hardware/gpu_simulator.py
@@ -270,6 +270,7 @@ def create_synthetic_gpu(name: str, vram_override_gb: float | None = None) -> GP
             vram_bytes=int(vram_gb * _GiB),
             memory_bandwidth_gbps=bandwidth,
             shared_memory=True,
+            vram_overridden=vram_override_gb is not None,
         )
 
     spec = _lookup_dbgpu(name)
@@ -315,4 +316,5 @@ def create_synthetic_gpu(name: str, vram_override_gb: float | None = None) -> GP
         compute_capability=compute_cap,
         memory_bandwidth_gbps=bandwidth,
         shared_memory=amd_shared_memory_apu,
+        vram_overridden=vram_override_gb is not None,
     )

--- a/src/whichllm/hardware/types.py
+++ b/src/whichllm/hardware/types.py
@@ -14,6 +14,7 @@ class GPUInfo:
     rocm_version: str | None = None
     memory_bandwidth_gbps: float | None = None  # from lookup table
     shared_memory: bool = False
+    vram_overridden: bool = False
 
 
 @dataclass

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,7 @@ from whichllm.cli import (
     _resolve_speed_filter,
     _search_model,
     _validate_evidence,
+    _validate_gpu_flags,
     app,
 )
 from whichllm.utils import _current_version
@@ -99,6 +100,125 @@ def test_apply_gpu_overrides_accepts_multiple_simulated_gpus():
     assert len(hw.gpus) == 2
     assert all(gpu.vendor == "nvidia" for gpu in hw.gpus)
     assert all(gpu.vram_bytes == 24 * 1024**3 for gpu in hw.gpus)
+
+
+def test_validate_gpu_flags_allows_detected_vram_override():
+    _validate_gpu_flags(cpu_only=False, gpu=None, vram=8.0, bandwidth=None)
+
+
+def test_validate_gpu_flags_rejects_non_positive_overrides():
+    with pytest.raises(Exit):
+        _validate_gpu_flags(cpu_only=False, gpu=None, vram=0, bandwidth=None)
+    with pytest.raises(Exit):
+        _validate_gpu_flags(cpu_only=False, gpu=None, vram=None, bandwidth=-1)
+
+
+def test_validate_gpu_flags_rejects_gpu_index_with_simulated_gpu():
+    with pytest.raises(Exit):
+        _validate_gpu_flags(
+            cpu_only=False,
+            gpu=["RTX 4090"],
+            vram=24.0,
+            bandwidth=None,
+            gpu_index=0,
+        )
+
+
+def test_apply_gpu_overrides_updates_detected_shared_memory_gpu():
+    hw = HardwareInfo(
+        gpus=[
+            GPUInfo(
+                name="Intel UHD Graphics",
+                vendor="intel",
+                vram_bytes=0,
+                shared_memory=True,
+                memory_bandwidth_gbps=None,
+            )
+        ],
+        cpu_name="CPU",
+        cpu_cores=8,
+        ram_bytes=32 * 1024**3,
+        disk_free_bytes=100 * 1024**3,
+        os="linux",
+    )
+
+    _apply_gpu_overrides(hw, cpu_only=False, gpu=None, vram=6.0, bandwidth=88.5)
+
+    assert hw.gpus[0].vram_bytes == 6 * 1024**3
+    assert hw.gpus[0].usable_vram_bytes is None
+    assert hw.gpus[0].memory_bandwidth_gbps == 88.5
+    assert hw.gpus[0].shared_memory is True
+    assert hw.gpus[0].vram_overridden is True
+
+
+def test_apply_gpu_overrides_updates_selected_detected_gpu_only():
+    hw = HardwareInfo(
+        gpus=[
+            GPUInfo(
+                name="NVIDIA RTX 4060",
+                vendor="nvidia",
+                vram_bytes=8 * 1024**3,
+                memory_bandwidth_gbps=272.0,
+            ),
+            GPUInfo(
+                name="Intel UHD Graphics",
+                vendor="intel",
+                vram_bytes=0,
+                shared_memory=True,
+            ),
+        ],
+        cpu_name="CPU",
+        cpu_cores=8,
+        ram_bytes=32 * 1024**3,
+        disk_free_bytes=100 * 1024**3,
+        os="linux",
+    )
+
+    _apply_gpu_overrides(
+        hw, cpu_only=False, gpu=None, vram=4.0, bandwidth=60.0, gpu_index=1
+    )
+
+    assert hw.gpus[0].vram_bytes == 8 * 1024**3
+    assert hw.gpus[0].memory_bandwidth_gbps == 272.0
+    assert hw.gpus[1].vram_bytes == 4 * 1024**3
+    assert hw.gpus[1].memory_bandwidth_gbps == 60.0
+    assert hw.gpus[1].vram_overridden is True
+
+
+def test_apply_gpu_overrides_requires_gpu_index_for_multiple_detected_gpus():
+    hw = HardwareInfo(
+        gpus=[
+            GPUInfo(name="GPU 0", vendor="nvidia", vram_bytes=8 * 1024**3),
+            GPUInfo(name="GPU 1", vendor="intel", vram_bytes=0, shared_memory=True),
+        ],
+        cpu_name="CPU",
+        cpu_cores=8,
+        ram_bytes=32 * 1024**3,
+        disk_free_bytes=100 * 1024**3,
+        os="linux",
+    )
+
+    with pytest.raises(Exit):
+        _apply_gpu_overrides(hw, cpu_only=False, gpu=None, vram=4.0)
+
+
+def test_apply_gpu_overrides_updates_simulated_gpu_bandwidth():
+    hw = HardwareInfo(gpus=[], ram_bytes=32 * 1024**3, os="linux")
+
+    _apply_gpu_overrides(
+        hw, cpu_only=False, gpu=["Unknown GPU"], vram=4.0, bandwidth=72.0
+    )
+
+    assert len(hw.gpus) == 1
+    assert hw.gpus[0].vram_bytes == 4 * 1024**3
+    assert hw.gpus[0].memory_bandwidth_gbps == 72.0
+
+
+def test_apply_gpu_overrides_rejects_override_without_gpu():
+    hw = HardwareInfo(gpus=[], ram_bytes=32 * 1024**3, os="linux")
+
+    with pytest.raises(Exit):
+        _apply_gpu_overrides(hw, cpu_only=False, gpu=None, vram=4.0)
 
 
 def test_include_vision_candidates_by_profile():

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -123,6 +123,33 @@ def test_ram_budget_caps_shared_memory_gpu_fit_pool():
     assert result.vram_available_bytes == 8 * _GiB
 
 
+def test_shared_memory_manual_vram_override_caps_available_gpu_memory():
+    model = _make_model(8_000_000_000)
+    variant = _make_variant(4_000_000_000)
+    hw = HardwareInfo(
+        gpus=[
+            GPUInfo(
+                name="Intel UHD Graphics",
+                vendor="intel",
+                vram_bytes=1 * _GiB,
+                shared_memory=True,
+                vram_overridden=True,
+            )
+        ],
+        cpu_name="Intel CPU",
+        cpu_cores=8,
+        ram_bytes=32 * _GiB,
+        disk_free_bytes=100 * _GiB,
+        os="linux",
+    )
+
+    result = check_compatibility(model, variant, hw)
+
+    assert result.can_run is True
+    assert result.vram_available_bytes == 1 * _GiB
+    assert result.fit_type == "cpu_only"
+
+
 def test_shared_memory_amd_apu_uses_system_memory_pool():
     model = _make_model(120_000_000_000)
     variant = _make_variant(55_000_000_000)


### PR DESCRIPTION
## What

  Add manual hardware override options for detected GPU/iGPU environments.

  - Allow `--vram` to override detected GPU usable VRAM, not only simulated GPUs
  - Add `--bandwidth` / `--ram-bandwidth` to override GPU/RAM bandwidth estimates
  - Add `--gpu-index` for selecting which detected GPU to override on multi-GPU systems
  - Preserve existing `--gpu ... --vram ...` simulation behavior
  - Document the new iGPU/unified-memory override workflow

  ## Why

  Fixes #132.

  Some iGPU and unified-memory systems can report misleading available GPU memory or memory bandwidth. This can cause whichllm to rank models that appear runnable on paper but are unrealistic on the
  actual machine.

  Manual overrides let users provide their real usable VRAM and RAM bandwidth so ranking and speed estimates are more accurate.

  ## Testing

  - [x] Tests pass (`uv run --no-dev --with pytest pytest`)
  - [x] New tests added
  - [ ] Tested on real hardware

  ## Notes

  This branch is based on latest `origin/main`.

  For example:

  ```bash
  whichllm --vram 8 --ram-bandwidth 68
  whichllm --gpu-index 1 --vram 8 --bandwidth 68
