### PR TITLE
chore: add pre-commit config for ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.20
+    hooks:
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format


### PR DESCRIPTION
Closes #127.

Adds a `.pre-commit-config.yaml` so contributors catch ruff lint/format issues locally before CI.

The hooks mirror the existing `lint.yml` workflow (`ruff check` + `ruff format --check`), so this is purely additive with no change to CI behavior:

```yaml
repos:
  - repo: https://github.com/astral-sh/ruff-pre-commit
    rev: v0.15.20
    hooks:
      - id: ruff-check
        args: [--fix]
      - id: ruff-format
```

Notes:
- Pinned to the current `ruff-pre-commit` tag (`v0.15.20`) rather than the older `v0.12.1` from the issue.
- Used the `ruff-check` hook id (the current name; `ruff` is now a legacy alias).
- Verified locally with `pre-commit run --all-files` — both hooks pass cleanly against `main` (no files reformatted), consistent with the green lint workflow.

One optional follow-up I left out to keep this minimal: `ruff` is unpinned in `lint.yml` while the hook here is pinned, so the two can drift over time. Happy to pin CI and/or add a shared `[tool.ruff]` to `pyproject.toml` in a separate PR if you'd like them kept in lockstep.
