### PR TITLE
Resolve GGUF artifact links

### DIFF
--- a/src/whichllm/cli.py
+++ b/src/whichllm/cli.py
@@ -12,6 +12,11 @@ from rich.console import Console
 
 from whichllm.constants import _GiB
 from whichllm.hardware.types import HardwareInfo
+from whichllm.models.artifacts import (
+    attach_resolved_artifacts,
+    find_gguf_variant,
+    resolve_ranked_gguf_artifact,
+)
 from whichllm.models.types import GGUFVariant, ModelInfo
 from whichllm.utils import _current_version, CONTEXT_LENGTH
 
@@ -22,6 +27,9 @@ app = typer.Typer(
     invoke_without_command=True,
 )
 console = Console()
+
+_find_gguf_variant = find_gguf_variant
+_resolve_ranked_gguf_for_run = resolve_ranked_gguf_artifact
 
 
 def _run_async(coro):
@@ -671,6 +679,7 @@ def main(
 
         # 上位候補の公開日時が欠けている場合のみ補完して表示品質を上げる
         if results:
+            attach_resolved_artifacts(results, all_models, quant_filter=quant)
             try:
                 if _fill_missing_published_at(
                     all_models, results, fetch_model_published_at
@@ -1073,81 +1082,6 @@ def _pick_gguf_variant(model, quant_filter: str | None = None):
     return model.gguf_variants[0]
 
 
-def _find_gguf_variant(model: ModelInfo, quant_type: str) -> GGUFVariant | None:
-    for variant in model.gguf_variants:
-        if variant.quant_type.upper() == quant_type.upper():
-            return variant
-    return None
-
-
-def _is_same_model_family(candidate: ModelInfo, selected: ModelInfo) -> bool:
-    if candidate.id == selected.id:
-        return True
-    if candidate.family_id and selected.family_id:
-        if candidate.family_id == selected.family_id:
-            return True
-    if candidate.base_model and candidate.base_model == selected.id:
-        return True
-    if selected.base_model and selected.base_model == candidate.id:
-        return True
-    if candidate.base_model and selected.base_model:
-        return candidate.base_model == selected.base_model
-    return False
-
-
-def _has_compatible_parameter_count(candidate: ModelInfo, selected: ModelInfo) -> bool:
-    if candidate.parameter_count <= 0 or selected.parameter_count <= 0:
-        return True
-    smaller = min(candidate.parameter_count, selected.parameter_count)
-    larger = max(candidate.parameter_count, selected.parameter_count)
-    return (larger / smaller) <= 2.0
-
-
-def _resolve_ranked_gguf_for_run(
-    selected_model: ModelInfo,
-    selected_variant: GGUFVariant,
-    models: list[ModelInfo],
-    quant_filter: str | None = None,
-) -> tuple[ModelInfo, GGUFVariant] | None:
-    """Resolve a ranked GGUF candidate to a real GGUF repo/file for `run`.
-
-    The ranker may synthesize GGUF variants for official safetensors-only repos
-    so they can be scored realistically. `run` cannot execute those synthetic
-    files directly, so it must find a real GGUF sibling before launching.
-    """
-    desired_quant = quant_filter or selected_variant.quant_type
-
-    if selected_model.gguf_variants:
-        variant = _find_gguf_variant(selected_model, desired_quant)
-        return (selected_model, variant) if variant else None
-
-    candidates: list[tuple[bool, int, int, ModelInfo, GGUFVariant]] = []
-    for model in models:
-        if not model.gguf_variants or not _is_same_model_family(model, selected_model):
-            continue
-        if not _has_compatible_parameter_count(model, selected_model):
-            continue
-        variant = _find_gguf_variant(model, desired_quant)
-        if not variant:
-            continue
-        explicit_base = model.base_model == selected_model.id
-        candidates.append(
-            (
-                explicit_base,
-                model.downloads,
-                model.likes,
-                model,
-                variant,
-            )
-        )
-
-    if not candidates:
-        return None
-
-    _, _, _, model, variant = max(candidates, key=lambda item: item[:3])
-    return model, variant
-
-
 def _resolve_model_deps(model, variant) -> tuple[list[str], str]:
     """Determine pip dependencies and script type for a model.
 
@@ -1350,7 +1284,7 @@ def run(
         model = None
         for ranked in results:
             if ranked.gguf_variant:
-                resolved = _resolve_ranked_gguf_for_run(
+                resolved = resolve_ranked_gguf_artifact(
                     ranked.model,
                     ranked.gguf_variant,
                     all_models,

--- a/src/whichllm/cli.py
+++ b/src/whichllm/cli.py
@@ -17,7 +17,7 @@ from whichllm.models.artifacts import (
     find_gguf_variant,
     resolve_ranked_gguf_artifact,
 )
-from whichllm.models.types import GGUFVariant, ModelInfo
+from whichllm.models.types import ModelInfo
 from whichllm.utils import _current_version, CONTEXT_LENGTH
 
 app = typer.Typer(

--- a/src/whichllm/engine/types.py
+++ b/src/whichllm/engine/types.py
@@ -26,3 +26,5 @@ class CompatibilityResult:
     context_fits: bool = True  # False when known model max context < requested
     uses_multi_gpu: bool = False
     multi_gpu_effective_vram_bytes: int | None = None
+    artifact_model: ModelInfo | None = None
+    artifact_variant: GGUFVariant | None = None

--- a/src/whichllm/models/artifacts.py
+++ b/src/whichllm/models/artifacts.py
@@ -1,0 +1,105 @@
+"""Resolve runnable/downloadable model artifacts for ranked recommendations."""
+
+from __future__ import annotations
+
+from whichllm.engine.types import CompatibilityResult
+from whichllm.models.types import GGUFVariant, ModelInfo
+
+
+def find_gguf_variant(model: ModelInfo, quant_type: str) -> GGUFVariant | None:
+    """Return the model's GGUF variant for a quantization type."""
+    for variant in model.gguf_variants:
+        if variant.quant_type.upper() == quant_type.upper():
+            return variant
+    return None
+
+
+def is_same_model_family(candidate: ModelInfo, selected: ModelInfo) -> bool:
+    """Return whether two repos represent the same base model family."""
+    if candidate.id == selected.id:
+        return True
+    if candidate.family_id and selected.family_id:
+        if candidate.family_id == selected.family_id:
+            return True
+    if candidate.base_model and candidate.base_model == selected.id:
+        return True
+    if selected.base_model and selected.base_model == candidate.id:
+        return True
+    if candidate.base_model and selected.base_model:
+        return candidate.base_model == selected.base_model
+    return False
+
+
+def has_compatible_parameter_count(candidate: ModelInfo, selected: ModelInfo) -> bool:
+    """Reject artifact repos that are clearly a different model size."""
+    if candidate.parameter_count <= 0 or selected.parameter_count <= 0:
+        return True
+    smaller = min(candidate.parameter_count, selected.parameter_count)
+    larger = max(candidate.parameter_count, selected.parameter_count)
+    return (larger / smaller) <= 2.0
+
+
+def resolve_ranked_gguf_artifact(
+    selected_model: ModelInfo,
+    selected_variant: GGUFVariant,
+    models: list[ModelInfo],
+    quant_filter: str | None = None,
+) -> tuple[ModelInfo, GGUFVariant] | None:
+    """Resolve a ranked GGUF candidate to a real HF repo/file.
+
+    The ranker may synthesize GGUF variants for official safetensors-only repos
+    so they can be scored realistically. Output surfaces and `run` need the
+    actual GGUF repository and filename when one exists.
+    """
+    desired_quant = quant_filter or selected_variant.quant_type
+
+    if selected_model.gguf_variants:
+        variant = find_gguf_variant(selected_model, desired_quant)
+        return (selected_model, variant) if variant else None
+
+    candidates: list[tuple[bool, int, int, ModelInfo, GGUFVariant]] = []
+    for model in models:
+        if not model.gguf_variants or not is_same_model_family(model, selected_model):
+            continue
+        if not has_compatible_parameter_count(model, selected_model):
+            continue
+        variant = find_gguf_variant(model, desired_quant)
+        if not variant:
+            continue
+        explicit_base = model.base_model == selected_model.id
+        candidates.append(
+            (
+                explicit_base,
+                model.downloads,
+                model.likes,
+                model,
+                variant,
+            )
+        )
+
+    if not candidates:
+        return None
+
+    _, _, _, model, variant = max(candidates, key=lambda item: item[:3])
+    return model, variant
+
+
+def attach_resolved_artifacts(
+    results: list[CompatibilityResult],
+    models: list[ModelInfo],
+    quant_filter: str | None = None,
+) -> None:
+    """Populate artifact fields on ranked results when a real artifact exists."""
+    for result in results:
+        result.artifact_model = None
+        result.artifact_variant = None
+        if not result.gguf_variant:
+            continue
+        resolved = resolve_ranked_gguf_artifact(
+            result.model,
+            result.gguf_variant,
+            models,
+            quant_filter=quant_filter,
+        )
+        if resolved:
+            result.artifact_model, result.artifact_variant = resolved

--- a/src/whichllm/output/json_output.py
+++ b/src/whichllm/output/json_output.py
@@ -38,6 +38,10 @@ def display_json(results: list[CompatibilityResult], hardware: HardwareInfo) -> 
             {
                 "rank": i,
                 "model_id": r.model.id,
+                "artifact_repo_id": r.artifact_model.id if r.artifact_model else None,
+                "artifact_filename": (
+                    r.artifact_variant.filename if r.artifact_variant else None
+                ),
                 "parameter_count": r.model.parameter_count,
                 "published_at": r.model.published_at,
                 "downloads": r.model.downloads,

--- a/src/whichllm/output/markdown.py
+++ b/src/whichllm/output/markdown.py
@@ -58,6 +58,12 @@ def _format_markdown_params(result: CompatibilityResult) -> str:
     return params
 
 
+def _format_markdown_model(result: CompatibilityResult) -> str:
+    if not result.artifact_model:
+        return result.model.id
+    return f"[{result.model.id}](https://huggingface.co/{result.artifact_model.id})"
+
+
 def _markdown_table(headers: list[str], rows: list[list[str]]) -> str:
     lines = [
         "| " + " | ".join(headers) + " |",
@@ -107,7 +113,7 @@ def display_markdown(
         rows = [
             [
                 str(index),
-                result.model.id,
+                _format_markdown_model(result),
                 _format_markdown_params(result),
                 effective_quant_type(result.model, result.gguf_variant),
                 _format_markdown_fit(result.fit_type),
@@ -133,7 +139,7 @@ def display_markdown(
         rows = [
             [
                 str(index),
-                result.model.id,
+                _format_markdown_model(result),
                 _format_markdown_params(result),
                 effective_quant_type(result.model, result.gguf_variant),
                 _format_published_at(result.model.published_at),

--- a/src/whichllm/output/ranking.py
+++ b/src/whichllm/output/ranking.py
@@ -38,6 +38,12 @@ def _detect_specializations(model_id: str) -> list[str]:
     return tags
 
 
+def _artifact_model_id(result: CompatibilityResult) -> str:
+    if result.artifact_model:
+        return result.artifact_model.id
+    return result.model.id
+
+
 def _top_pick_confidence(results: list[CompatibilityResult]) -> tuple[str, str]:
     """Return confidence level and explanation for top pick."""
     top = results[0]
@@ -227,7 +233,7 @@ def display_ranking(
             params_str += f" ({_format_params(r.model.parameter_count_active)}a)"
 
         model_link = Text(r.model.id, style="cyan")
-        model_link.stylize(f"link https://huggingface.co/{r.model.id}")
+        model_link.stylize(f"link https://huggingface.co/{_artifact_model_id(r)}")
         if show_status:
             model_link.append(f"\n{params_str}", style="dim")
 

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1,0 +1,47 @@
+"""Tests for resolving concrete downloadable artifacts."""
+
+from whichllm.engine.types import CompatibilityResult
+from whichllm.models.artifacts import attach_resolved_artifacts
+from whichllm.models.types import GGUFVariant, ModelInfo
+
+
+def test_attach_resolved_artifacts_maps_synthetic_quant_to_real_gguf_repo():
+    base = ModelInfo(
+        id="Qwen/Qwen3-4B-Thinking-2507",
+        family_id="qwen3-4b-thinking",
+        name="Qwen3-4B-Thinking-2507",
+        parameter_count=4_000_000_000,
+        downloads=494_000,
+    )
+    gguf_repo = ModelInfo(
+        id="MaziyarPanahi/Qwen3-4B-Thinking-2507-GGUF",
+        family_id="qwen3-4b-thinking",
+        name="Qwen3-4B-Thinking-2507-GGUF",
+        parameter_count=4_000_000_000,
+        downloads=26_000,
+        base_model="Qwen/Qwen3-4B-Thinking-2507",
+        gguf_variants=[
+            GGUFVariant(
+                filename="Qwen3-4B-Thinking-2507-Q3_K_M.gguf",
+                quant_type="Q3_K_M",
+                file_size_bytes=2_000_000_000,
+            )
+        ],
+    )
+    synthetic = GGUFVariant(
+        filename="Qwen3-4B-Thinking-2507.Q3_K_M.gguf",
+        quant_type="Q3_K_M",
+        file_size_bytes=2_000_000_000,
+    )
+    result = CompatibilityResult(
+        model=base,
+        gguf_variant=synthetic,
+        can_run=True,
+        vram_required_bytes=3_000_000_000,
+        vram_available_bytes=8_000_000_000,
+    )
+
+    attach_resolved_artifacts([result], [base, gguf_repo])
+
+    assert result.artifact_model is gguf_repo
+    assert result.artifact_variant is gguf_repo.gguf_variants[0]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1268,6 +1268,71 @@ def test_json_output_includes_benchmark_source_and_confidence():
     entry = data["models"][0]
     assert data["hardware"]["ram_budget_bytes"] == 32 * 1024**3
     assert data["hardware"]["budget_notes"] == ["RAM budget: 32.0 GB"]
+    assert entry["artifact_repo_id"] is None
+    assert entry["artifact_filename"] is None
     assert entry["benchmark_status"] == "estimated"
     assert entry["benchmark_source"] == "line_interp"
     assert entry["benchmark_confidence"] == 0.34
+
+
+def test_json_output_includes_resolved_artifact_fields():
+    """display_json should expose the actual GGUF repo/file when resolved."""
+    import json as json_mod
+    from io import StringIO
+
+    from rich.console import Console
+
+    from whichllm.output.display import display_json
+
+    model = ModelInfo(
+        id="Qwen/Qwen3-4B-Thinking-2507",
+        family_id="qwen3-4b-thinking",
+        name="Qwen3-4B-Thinking-2507",
+        parameter_count=4_000_000_000,
+    )
+    artifact = ModelInfo(
+        id="MaziyarPanahi/Qwen3-4B-Thinking-2507-GGUF",
+        family_id="qwen3-4b-thinking",
+        name="Qwen3-4B-Thinking-2507-GGUF",
+        parameter_count=4_000_000_000,
+    )
+    result = CompatibilityResult(
+        model=model,
+        gguf_variant=GGUFVariant(
+            filename="Qwen3-4B-Thinking-2507.Q3_K_M.gguf",
+            quant_type="Q3_K_M",
+            file_size_bytes=2_000_000_000,
+        ),
+        artifact_model=artifact,
+        artifact_variant=GGUFVariant(
+            filename="Qwen3-4B-Thinking-2507-Q3_K_M.gguf",
+            quant_type="Q3_K_M",
+            file_size_bytes=2_000_000_000,
+        ),
+        can_run=True,
+        vram_required_bytes=3_000_000_000,
+        vram_available_bytes=8_000_000_000,
+    )
+    hw = HardwareInfo(
+        gpus=[],
+        cpu_name="Test CPU",
+        cpu_cores=8,
+        ram_bytes=64 * 1024**3,
+        disk_free_bytes=500 * 1024**3,
+        os="linux",
+    )
+
+    buf = StringIO()
+    import whichllm.output._console as console_mod
+
+    orig_console = console_mod.console
+    console_mod.console = Console(file=buf, force_terminal=False)
+    try:
+        display_json([result], hw)
+    finally:
+        console_mod.console = orig_console
+
+    entry = json_mod.loads(buf.getvalue().strip())["models"][0]
+    assert entry["model_id"] == "Qwen/Qwen3-4B-Thinking-2507"
+    assert entry["artifact_repo_id"] == "MaziyarPanahi/Qwen3-4B-Thinking-2507-GGUF"
+    assert entry["artifact_filename"] == "Qwen3-4B-Thinking-2507-Q3_K_M.gguf"

--- a/tests/test_markdown_output.py
+++ b/tests/test_markdown_output.py
@@ -151,8 +151,7 @@ def test_display_markdown_links_to_resolved_artifact_repo():
 
     assert (
         "[Qwen/Qwen3-4B-Thinking-2507]"
-        "(https://huggingface.co/MaziyarPanahi/Qwen3-4B-Thinking-2507-GGUF)"
-        in output
+        "(https://huggingface.co/MaziyarPanahi/Qwen3-4B-Thinking-2507-GGUF)" in output
     )
     assert "Q3_K_M" in output
 

--- a/tests/test_markdown_output.py
+++ b/tests/test_markdown_output.py
@@ -127,6 +127,36 @@ def test_display_markdown_details_table_uses_metadata_columns():
     )
 
 
+def test_display_markdown_links_to_resolved_artifact_repo():
+    result = _result(1)
+    result.model.id = "Qwen/Qwen3-4B-Thinking-2507"
+    result.gguf_variant = GGUFVariant(
+        filename="Qwen3-4B-Thinking-2507.Q3_K_M.gguf",
+        quant_type="Q3_K_M",
+        file_size_bytes=2 * 1024**3,
+    )
+    result.artifact_model = ModelInfo(
+        id="MaziyarPanahi/Qwen3-4B-Thinking-2507-GGUF",
+        family_id=result.model.family_id,
+        name="Qwen3-4B-Thinking-2507-GGUF",
+        parameter_count=result.model.parameter_count,
+    )
+    result.artifact_variant = GGUFVariant(
+        filename="Qwen3-4B-Thinking-2507-Q3_K_M.gguf",
+        quant_type="Q3_K_M",
+        file_size_bytes=2 * 1024**3,
+    )
+
+    output = _capture_markdown([result], _hardware(), show_status=False)
+
+    assert (
+        "[Qwen/Qwen3-4B-Thinking-2507]"
+        "(https://huggingface.co/MaziyarPanahi/Qwen3-4B-Thinking-2507-GGUF)"
+        in output
+    )
+    assert "Q3_K_M" in output
+
+
 def test_display_markdown_empty_results():
     output = _capture_markdown(
         [],


### PR DESCRIPTION
## What

  - Resolve ranked GGUF recommendations to their actual downloadable artifact repo/file.
  - Add artifact metadata to ranking results and JSON output.
  - Update Rich/Markdown output so model links can point to the real GGUF repo while preserving the recommended base model ID.

  ## Why

  Fixes #137.

  Some recommendations are scored as an official base model plus a GGUF quantization, but the actual GGUF files may live in a third-party repo. The output previously linked only to the base model repo, so
  users could click a `Q3_K_M` recommendation and land on a repo that does not contain that GGUF artifact.

  ## Testing

  - [ ] Tests pass (`pytest`)
  - [x] New tests added (if applicable)
  - [ ] Tested on real hardware (if hardware-related)

  Manual verification:
  - Ran `git diff --check`.
  - Ran `python -m compileall src/whichllm tests/test_artifacts.py tests/test_markdown_output.py tests/test_cli.py`.
  - Could not run full `pytest` locally because `uv run pytest` failed while building `pyarrow==23.0.1`, and the local Python environments do not have `pytest` installed.

  ## Notes

  This keeps ranking based on the recommended/base model, but exposes the resolved GGUF artifact repo and filename for output/download surfaces.