### PR TITLE
fix: resolve bandwidth for RTX Ada Generation laptop workstation GPUs

### DIFF
--- a/src/whichllm/hardware/gpu_db.py
+++ b/src/whichllm/hardware/gpu_db.py
@@ -40,6 +40,7 @@ _LAPTOP_GPU_RE = re.compile(r"\blaptop gpu\b", re.IGNORECASE)
 _TRAILING_GRAPHICS_RE = re.compile(r"\bgraphics\s*$", re.IGNORECASE)
 _WHITESPACE_RE = re.compile(r"\s+")
 _MOBILE_MARKER_RE = re.compile(r"\b(?:laptop|mobile|max-?q)\b", re.IGNORECASE)
+_MOBILE_WORD_RE = re.compile(r"\bmobile\b", re.IGNORECASE)
 # Driver names write VRAM bins without a space ("RTX A2000 12GB"); dbgpu
 # writes "RTX A2000 12 GB" (#98).
 _VRAM_NOSPACE_RE = re.compile(r"\b(\d+)GB\b", re.IGNORECASE)
@@ -57,6 +58,12 @@ def _normalize_detected_name(name: str) -> str:
     text = _LAPTOP_GPU_RE.sub("Mobile", text)
     text = _TRAILING_GRAPHICS_RE.sub("", text)
     text = _VRAM_NOSPACE_RE.sub(r"\1 GB", text)
+    # Canonicalize the Mobile marker to a trailing position. dbgpu names the
+    # workstation Ada laptops "RTX 2000 Mobile Ada Generation" (marker in the
+    # middle) while drivers emit "RTX 2000 Ada Generation Laptop GPU" (marker
+    # last). Moving it to the end on both sides makes the two orderings match.
+    if _MOBILE_WORD_RE.search(text):
+        text = f"{_MOBILE_WORD_RE.sub('', text)} Mobile"
     return _WHITESPACE_RE.sub(" ", text).strip()
 
 

--- a/tests/test_gpu_db.py
+++ b/tests/test_gpu_db.py
@@ -106,6 +106,37 @@ def test_resolve_a2000_12gb_vram_bin_from_dbgpu():
     assert resolve_detected_bandwidth("NVIDIA RTX A2000 12GB", 12 * _GiB) == 288.0
 
 
+def test_resolve_ada_workstation_laptop_family_from_dbgpu():
+    # The whole RTX Ada Generation Laptop workstation line reported BW: N/A:
+    # dbgpu names them "RTX 2000 Mobile Ada Generation" (marker mid-string)
+    # while drivers emit "RTX 2000 Ada Generation Laptop GPU" (marker last).
+    # The normalizer must reconcile the two orderings so dbgpu's value is used.
+    expected = {
+        "NVIDIA RTX 500 Ada Generation Laptop GPU": 128.0,
+        "NVIDIA RTX 1000 Ada Generation Laptop GPU": 192.0,
+        "NVIDIA RTX 2000 Ada Generation Laptop GPU": 256.0,
+        "NVIDIA RTX 3000 Ada Generation Laptop GPU": 256.0,
+        "NVIDIA RTX 3500 Ada Generation Laptop GPU": 432.0,
+        "NVIDIA RTX 4000 Ada Generation Laptop GPU": 432.0,
+        "NVIDIA RTX 5000 Ada Generation Laptop GPU": 576.0,
+    }
+    for name, bw in expected.items():
+        assert resolve_detected_bandwidth(name) == bw, name
+
+
+def test_normalize_relocates_mid_string_mobile_marker():
+    # Consumer laptops already carry a trailing marker and must be unchanged.
+    assert (
+        _normalize_detected_name("NVIDIA GeForce RTX 4060 Laptop GPU")
+        == "GeForce RTX 4060 Mobile"
+    )
+    # dbgpu's mid-string marker is moved to the tail to match driver ordering.
+    assert (
+        _normalize_detected_name("RTX 2000 Mobile Ada Generation")
+        == "RTX 2000 Ada Generation Mobile"
+    )
+
+
 def test_static_bandwidth_compound_lspci_name():
     # Ported from amd.py (#68): compound lspci names resolve via segment
     # splitting, first matching segment wins, "RX " prefix retried for bare


### PR DESCRIPTION
## What

Fix memory-bandwidth resolution for the RTX Ada Generation workstation laptop GPUs (RTX 500 / 1000 / 2000 / 3000 / 3500 / 4000 / 5000 Ada Laptop). They all resolved to "BW: N/A" even though dbgpu already ships their bandwidth.

The cause is a word-order mismatch in `_normalize_detected_name`. The driver reports `NVIDIA RTX 2000 Ada Generation Laptop GPU`, which the normalizer turned into `RTX 2000 Ada Generation Mobile` (marker at the end). dbgpu names the same card `RTX 2000 Mobile Ada Generation` (marker in the middle). The two normalized strings never matched, so the dbgpu lookup fell through to `None`.

The fix relocates the `Mobile` marker to a trailing position inside `_normalize_detected_name`. Because the dbgpu index is built with the same normalizer, both the driver name and the dbgpu name now canonicalize to `RTX 2000 Ada Generation Mobile` and match. No bandwidth values are hardcoded; every card resolves from dbgpu's own data.

## Why

These are common professional/mobile workstation cards. Without a bandwidth value the speed estimates fall back to a default, which produces worse recommendations for anyone on an Ada laptop. This is the same class of laptop-card bandwidth gap the resolver already guards against for consumer cards (issues #74, #61, #93).

Before:

```
RTX 500 Ada Generation Laptop GPU   -> None
RTX 1000 Ada Generation Laptop GPU  -> None
RTX 2000 Ada Generation Laptop GPU  -> None
RTX 3000 Ada Generation Laptop GPU  -> None
RTX 3500 Ada Generation Laptop GPU  -> None
RTX 4000 Ada Generation Laptop GPU  -> None
RTX 5000 Ada Generation Laptop GPU  -> None
```

After:

```
RTX 500 Ada Generation Laptop GPU   -> 128.0
RTX 1000 Ada Generation Laptop GPU  -> 192.0
RTX 2000 Ada Generation Laptop GPU  -> 256.0
RTX 3000 Ada Generation Laptop GPU  -> 256.0
RTX 3500 Ada Generation Laptop GPU  -> 432.0
RTX 4000 Ada Generation Laptop GPU  -> 432.0
RTX 5000 Ada Generation Laptop GPU  -> 576.0
```

The marker relocation is idempotent for cards that already carry a trailing marker, so consumer laptops (e.g. `GeForce RTX 4060 Laptop GPU`), the curated `RTX A3000 Laptop` entry, and all desktop cards are unchanged.

## Testing

- [x] Tests pass (`uv run pytest`, 468 passing)
- [x] New tests added: one pins the whole Ada workstation-laptop family against dbgpu's values, one pins the normalizer behavior (mid-string marker relocated, trailing marker untouched)
- [ ] Tested on real hardware: verified through `resolve_detected_bandwidth` (the same function `hardware/nvidia.py` uses for detected cards) against dbgpu's shipped specs; I do not have a physical Ada workstation laptop to confirm the end-to-end driver-name string

## Notes

The change is a normalizer fix in `hardware/gpu_db.py`, not a new entry in the curated bandwidth table, since dbgpu already had the data and it was only unreachable due to naming.
