### PR TITLE
test: make XDG cache-dir test portable on Windows

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,10 +13,10 @@ def test_cache_dir_defaults_to_dot_cache(monkeypatch):
     assert result == Path.home() / ".cache" / "whichllm"
 
 
-def test_cache_dir_respects_xdg_cache_home(monkeypatch):
-    monkeypatch.setenv("XDG_CACHE_HOME", "/tmp/custom-cache")
+def test_cache_dir_respects_xdg_cache_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
     result = _cache_dir()
-    assert result == Path("/tmp/custom-cache/whichllm")
+    assert result == tmp_path / "whichllm"
 
 
 def test_cache_dir_falls_back_on_empty_xdg(monkeypatch):


### PR DESCRIPTION
Closes #148

## What

Replace the hard-coded POSIX cache path in `test_cache_dir_respects_xdg_cache_home`
with pytest's platform-native `tmp_path` fixture.

## Why

`/tmp/custom-cache` is not an absolute path on Windows. The test therefore
expected an XDG cache path while `_cache_dir()` correctly fell back to the
default Windows cache location.

## Testing

- [ ] Full test suite (`uv run pytest`) not run locally: `uv`, pytest, and project dependencies are unavailable.
- [x] `git diff --check`
- [x] `python3 -m py_compile tests/test_utils.py`
- [x] Targeted cache-path assertion with a platform-native absolute path

## Notes

This changes test portability only; runtime cache behavior is unchanged.