### PR TITLE
fix(run): require provenance for synthetic GGUF artifacts

### DIFF
--- a/src/whichllm/models/artifacts.py
+++ b/src/whichllm/models/artifacts.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import re
+
 from whichllm.engine.types import CompatibilityResult
 from whichllm.models.types import GGUFVariant, ModelInfo
+
+_DERIVATIVE_PROVENANCE_TAGS = frozenset({"adapter", "finetune", "merge"})
 
 
 def find_gguf_variant(model: ModelInfo, quant_type: str) -> GGUFVariant | None:
@@ -14,22 +18,6 @@ def find_gguf_variant(model: ModelInfo, quant_type: str) -> GGUFVariant | None:
     return None
 
 
-def is_same_model_family(candidate: ModelInfo, selected: ModelInfo) -> bool:
-    """Return whether two repos represent the same base model family."""
-    if candidate.id == selected.id:
-        return True
-    if candidate.family_id and selected.family_id:
-        if candidate.family_id == selected.family_id:
-            return True
-    if candidate.base_model and candidate.base_model == selected.id:
-        return True
-    if selected.base_model and selected.base_model == candidate.id:
-        return True
-    if candidate.base_model and selected.base_model:
-        return candidate.base_model == selected.base_model
-    return False
-
-
 def has_compatible_parameter_count(candidate: ModelInfo, selected: ModelInfo) -> bool:
     """Reject artifact repos that are clearly a different model size."""
     if candidate.parameter_count <= 0 or selected.parameter_count <= 0:
@@ -37,6 +25,36 @@ def has_compatible_parameter_count(candidate: ModelInfo, selected: ModelInfo) ->
     smaller = min(candidate.parameter_count, selected.parameter_count)
     larger = max(candidate.parameter_count, selected.parameter_count)
     return (larger / smaller) <= 2.0
+
+
+def is_equivalent_quantization(candidate: ModelInfo, selected: ModelInfo) -> bool:
+    """Return whether provenance identifies a direct quantization of selected."""
+    candidate_name = re.sub(r"[^a-z0-9]+", "", candidate.name.casefold())
+    if candidate_name.endswith("gguf"):
+        candidate_name = candidate_name.removesuffix("gguf")
+    selected_name = re.sub(r"[^a-z0-9]+", "", selected.id.rsplit("/", 1)[-1].casefold())
+    selected_owner = (
+        re.sub(r"[^a-z0-9]+", "", selected.id.split("/", 1)[0].casefold())
+        if "/" in selected.id
+        else ""
+    )
+    accepted_names = {selected_name, f"{selected_owner}{selected_name}"}
+    normalized_tags = {tag.casefold() for tag in candidate.tags}
+    base_relations = {
+        parts[1]
+        for tag in normalized_tags
+        if len(parts := tag.split(":", 2)) == 3
+        and parts[0] == "base_model"
+        and parts[2] == selected.id.casefold()
+    }
+    return (
+        candidate.base_model is not None
+        and candidate.base_model.casefold() == selected.id.casefold()
+        and candidate.base_model_relation == "quantized"
+        and base_relations == {"quantized"}
+        and candidate_name in accepted_names
+        and not normalized_tags.intersection(_DERIVATIVE_PROVENANCE_TAGS)
+    )
 
 
 def resolve_ranked_gguf_artifact(
@@ -57,19 +75,19 @@ def resolve_ranked_gguf_artifact(
         variant = find_gguf_variant(selected_model, desired_quant)
         return (selected_model, variant) if variant else None
 
-    candidates: list[tuple[bool, int, int, ModelInfo, GGUFVariant]] = []
+    candidates: list[tuple[int, int, ModelInfo, GGUFVariant]] = []
     for model in models:
-        if not model.gguf_variants or not is_same_model_family(model, selected_model):
+        if not model.gguf_variants or not is_equivalent_quantization(
+            model, selected_model
+        ):
             continue
         if not has_compatible_parameter_count(model, selected_model):
             continue
         variant = find_gguf_variant(model, desired_quant)
         if not variant:
             continue
-        explicit_base = model.base_model == selected_model.id
         candidates.append(
             (
-                explicit_base,
                 model.downloads,
                 model.likes,
                 model,
@@ -80,7 +98,7 @@ def resolve_ranked_gguf_artifact(
     if not candidates:
         return None
 
-    _, _, _, model, variant = max(candidates, key=lambda item: item[:3])
+    _, _, model, variant = max(candidates, key=lambda item: item[:2])
     return model, variant
 
 

--- a/src/whichllm/models/cache.py
+++ b/src/whichllm/models/cache.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 CACHE_DIR = _cache_dir()
 CACHE_FILE = CACHE_DIR / "models.json"
 DEFAULT_TTL_SECONDS = 6 * 3600  # 6 hours
+CACHE_SCHEMA_VERSION = 3
 
 
 def _ensure_cache_dir() -> None:
@@ -26,6 +27,9 @@ def load_cache() -> list[dict] | None:
 
     try:
         data = json.loads(CACHE_FILE.read_text(encoding="utf-8"))
+        if data.get("schema_version") != CACHE_SCHEMA_VERSION:
+            logger.debug("Model cache schema is outdated")
+            return None
         cached_at = data.get("cached_at", 0)
         if time.time() - cached_at > DEFAULT_TTL_SECONDS:
             logger.debug("Cache expired")
@@ -40,6 +44,7 @@ def save_cache(models: list[dict]) -> None:
     """Save model data to cache."""
     _ensure_cache_dir()
     data = {
+        "schema_version": CACHE_SCHEMA_VERSION,
         "cached_at": time.time(),
         "models": models,
     }

--- a/src/whichllm/models/hf.py
+++ b/src/whichllm/models/hf.py
@@ -21,6 +21,7 @@ _MODEL_EXPANDS = [
     "safetensors",
     "gguf",
     "cardData",
+    "tags",
     "siblings",
     "evalResults",
 ]
@@ -30,6 +31,7 @@ _MODEL_DETAIL_EXPANDS = [
     "safetensors",
     "gguf",
     "cardData",
+    "tags",
     "siblings",
     "evalResults",
     "downloads",

--- a/src/whichllm/models/parser.py
+++ b/src/whichllm/models/parser.py
@@ -186,6 +186,25 @@ def _extract_base_model(card_data: dict) -> str | None:
     return None
 
 
+def _extract_base_model_relation(tags: object, base_model: str | None) -> str | None:
+    """Return the Hugging Face relation attached to the selected base model."""
+    if not base_model or not isinstance(tags, (list, tuple)):
+        return None
+
+    expected_model = base_model.casefold()
+    for tag in tags:
+        if not isinstance(tag, str):
+            continue
+        parts = tag.split(":", 2)
+        if (
+            len(parts) == 3
+            and parts[0].casefold() == "base_model"
+            and parts[2].casefold() == expected_model
+        ):
+            return parts[1].casefold()
+    return None
+
+
 def _resolve_active_params(
     config: dict,
     param_count: int,
@@ -242,6 +261,13 @@ def _parse_model(data: dict) -> ModelInfo | None:
     config = data.get("config", {}) or {}
     card_data = data.get("cardData", {}) or {}
     base_model = _extract_base_model(card_data)
+    raw_tags = data.get("tags")
+    tags = (
+        tuple(tag for tag in raw_tags if isinstance(tag, str))
+        if isinstance(raw_tags, list)
+        else ()
+    )
+    base_model_relation = _extract_base_model_relation(tags, base_model)
 
     param_count = _extract_param_count(data)
     param_count = _normalize_param_count(param_count, model_id, base_model)
@@ -290,6 +316,8 @@ def _parse_model(data: dict) -> ModelInfo | None:
         gguf_variants=gguf_variants,
         benchmark_scores=benchmark_scores,
         base_model=base_model,
+        base_model_relation=base_model_relation,
+        tags=tags,
         sliding_window=sliding_window,
         sliding_window_global_ratio=swa_global_ratio,
     )

--- a/src/whichllm/models/serialization.py
+++ b/src/whichllm/models/serialization.py
@@ -37,6 +37,8 @@ def models_to_dicts(models: list[ModelInfo]) -> list[dict]:
                 ],
                 "benchmark_scores": m.benchmark_scores,
                 "base_model": m.base_model,
+                "base_model_relation": m.base_model_relation,
+                "tags": list(m.tags),
                 "sliding_window": m.sliding_window,
                 "sliding_window_global_ratio": m.sliding_window_global_ratio,
             }
@@ -87,6 +89,8 @@ def dicts_to_models(data: list[dict]) -> list[ModelInfo]:
                 ],
                 benchmark_scores=d.get("benchmark_scores", {}),
                 base_model=base_model,
+                base_model_relation=d.get("base_model_relation"),
+                tags=tuple(d.get("tags", [])),
                 sliding_window=d.get("sliding_window"),
                 sliding_window_global_ratio=d.get("sliding_window_global_ratio"),
             )

--- a/src/whichllm/models/types.py
+++ b/src/whichllm/models/types.py
@@ -27,6 +27,8 @@ class ModelInfo:
     gguf_variants: list[GGUFVariant] = field(default_factory=list)
     benchmark_scores: dict[str, float] = field(default_factory=dict)
     base_model: str | None = None  # cardData.base_model
+    base_model_relation: str | None = None  # e.g. quantized, finetune, merge
+    tags: tuple[str, ...] = ()  # Hugging Face provenance and capability tags
     # Sliding-window-attention KV-cache modeling. Only populated for
     # architectures whose mainline runtimes actually honor interleaved SWA
     # (Gemma-2/3, gpt-oss, Cohere2); left None otherwise so VRAM estimates

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -20,6 +20,8 @@ def test_attach_resolved_artifacts_maps_synthetic_quant_to_real_gguf_repo():
         parameter_count=4_000_000_000,
         downloads=26_000,
         base_model="Qwen/Qwen3-4B-Thinking-2507",
+        base_model_relation="quantized",
+        tags=("base_model:quantized:Qwen/Qwen3-4B-Thinking-2507",),
         gguf_variants=[
             GGUFVariant(
                 filename="Qwen3-4B-Thinking-2507-Q3_K_M.gguf",

--- a/tests/test_cache_encoding.py
+++ b/tests/test_cache_encoding.py
@@ -35,7 +35,11 @@ class _WritableCacheFile:
 
 def test_model_cache_reads_and_writes_utf8(monkeypatch, tmp_path):
     reader = _ReadableCacheFile(
-        {"cached_at": time.time(), "models": [{"id": "test/Omega-Ω"}]}
+        {
+            "schema_version": cache_mod.CACHE_SCHEMA_VERSION,
+            "cached_at": time.time(),
+            "models": [{"id": "test/Omega-Ω"}],
+        }
     )
     monkeypatch.setattr(cache_mod, "CACHE_FILE", reader)
     assert cache_mod.load_cache() == [{"id": "test/Omega-Ω"}]
@@ -47,6 +51,15 @@ def test_model_cache_reads_and_writes_utf8(monkeypatch, tmp_path):
     cache_mod.save_cache([{"id": "test/Omega-Ω"}])
     assert writer.encoding == "utf-8"
     assert "Ω" in writer.text
+
+
+def test_model_cache_rejects_missing_provenance_schema(monkeypatch):
+    reader = _ReadableCacheFile(
+        {"cached_at": time.time(), "models": [{"id": "test/old-cache"}]}
+    )
+    monkeypatch.setattr(cache_mod, "CACHE_FILE", reader)
+
+    assert cache_mod.load_cache() is None
 
 
 def test_benchmark_cache_reads_and_writes_utf8(monkeypatch, tmp_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -970,6 +970,8 @@ def test_resolve_ranked_synthetic_gguf_to_real_repo():
         parameter_count=27_000_000_000,
         downloads=200_000,
         base_model="Qwen/Qwen3.6-27B",
+        base_model_relation="quantized",
+        tags=("base_model:quantized:Qwen/Qwen3.6-27B",),
         gguf_variants=[
             GGUFVariant(
                 filename="Qwen3.6-27B-Q4_K_M.gguf",
@@ -990,6 +992,269 @@ def test_resolve_ranked_synthetic_gguf_to_real_repo():
     model, variant = resolved
     assert model.id == "unsloth/Qwen3.6-27B-GGUF"
     assert variant.filename == "Qwen3.6-27B-Q4_K_M.gguf"
+
+
+def test_resolve_ranked_synthetic_gguf_rejects_finetuned_repo():
+    selected = ModelInfo(
+        id="Qwen/Qwen3.6-27B",
+        family_id="qwen3-27b",
+        name="Qwen3.6-27B",
+        parameter_count=27_000_000_000,
+    )
+    finetuned_gguf = ModelInfo(
+        id="converter/Qwen3.6-27B-MTP-pi-tune-GGUF",
+        family_id="qwen3-27b",
+        name="Qwen3.6-27B-MTP-pi-tune-GGUF",
+        parameter_count=27_000_000_000,
+        downloads=1_000_000,
+        base_model="Qwen/Qwen3.6-27B",
+        base_model_relation="finetune",
+        tags=("base_model:finetune:Qwen/Qwen3.6-27B",),
+        gguf_variants=[
+            GGUFVariant(
+                filename="Qwen3.6-27B-MTP-Q4_K_M.gguf",
+                quant_type="Q4_K_M",
+                file_size_bytes=16_000_000_000,
+            )
+        ],
+    )
+    synthetic = GGUFVariant(
+        filename="Qwen3.6-27B.Q4_K_M.gguf",
+        quant_type="Q4_K_M",
+        file_size_bytes=16_000_000_000,
+    )
+
+    resolved = _resolve_ranked_gguf_for_run(
+        selected,
+        synthetic,
+        [selected, finetuned_gguf],
+    )
+
+    assert resolved is None
+
+
+def test_resolve_ranked_synthetic_gguf_rejects_unproven_base_relation():
+    selected = ModelInfo(
+        id="google/gemma-4-31B-it",
+        family_id="gemma-4-31b-it",
+        name="gemma-4-31B-it",
+        parameter_count=31_000_000_000,
+    )
+    unproven_gguf = ModelInfo(
+        id="converter/Gemma-4-31B-custom-GGUF",
+        family_id="gemma-4-31b-it",
+        name="Gemma-4-31B-custom-GGUF",
+        parameter_count=31_000_000_000,
+        downloads=1_000_000,
+        base_model="google/gemma-4-31b-it",
+        gguf_variants=[
+            GGUFVariant(
+                filename="Gemma-4-31B-Q4_K_M.gguf",
+                quant_type="Q4_K_M",
+                file_size_bytes=19_000_000_000,
+            )
+        ],
+    )
+    synthetic = GGUFVariant(
+        filename="gemma-4-31B-it.Q4_K_M.gguf",
+        quant_type="Q4_K_M",
+        file_size_bytes=19_000_000_000,
+    )
+
+    resolved = _resolve_ranked_gguf_for_run(
+        selected,
+        synthetic,
+        [selected, unproven_gguf],
+    )
+
+    assert resolved is None
+
+
+def test_resolve_ranked_synthetic_gguf_rejects_other_quantized_checkpoint():
+    selected = ModelInfo(
+        id="Qwen/Qwen3.6-27B",
+        family_id="qwen3-27b",
+        name="Qwen3.6-27B",
+        parameter_count=27_000_000_000,
+    )
+    other_checkpoint = ModelInfo(
+        id="converter/Qwen3.6-27B-tuned-GGUF",
+        family_id="qwen3-27b",
+        name="Qwen3.6-27B-tuned-GGUF",
+        parameter_count=27_000_000_000,
+        base_model="tuner/Qwen3.6-27B-tuned",
+        base_model_relation="quantized",
+        tags=("base_model:quantized:tuner/Qwen3.6-27B-tuned",),
+        gguf_variants=[
+            GGUFVariant(
+                filename="Qwen3.6-27B-tuned-Q4_K_M.gguf",
+                quant_type="Q4_K_M",
+                file_size_bytes=16_000_000_000,
+            )
+        ],
+    )
+    synthetic = GGUFVariant(
+        filename="Qwen3.6-27B.Q4_K_M.gguf",
+        quant_type="Q4_K_M",
+        file_size_bytes=16_000_000_000,
+    )
+
+    resolved = _resolve_ranked_gguf_for_run(
+        selected,
+        synthetic,
+        [selected, other_checkpoint],
+    )
+
+    assert resolved is None
+
+
+def test_resolve_ranked_synthetic_gguf_rejects_renamed_merge_claiming_quantized():
+    selected = ModelInfo(
+        id="Qwen/Qwen3.6-27B",
+        family_id="qwen3-27b",
+        name="Qwen3.6-27B",
+        parameter_count=27_000_000_000,
+    )
+    merged_gguf = ModelInfo(
+        id="converter/Qwopus3.6-27B-Fusion-GGUF",
+        family_id="qwen3-27b",
+        name="Qwopus3.6-27B-Fusion-GGUF",
+        parameter_count=27_000_000_000,
+        downloads=1_000_000,
+        base_model="Qwen/Qwen3.6-27B",
+        base_model_relation="quantized",
+        tags=(
+            "gguf",
+            "merge",
+            "task-vector",
+            "base_model:quantized:Qwen/Qwen3.6-27B",
+        ),
+        gguf_variants=[
+            GGUFVariant(
+                filename="Qwopus3.6-27B-Fusion-Q5_K_M.gguf",
+                quant_type="Q5_K_M",
+                file_size_bytes=19_000_000_000,
+            )
+        ],
+    )
+    synthetic = GGUFVariant(
+        filename="Qwen3.6-27B.Q5_K_M.gguf",
+        quant_type="Q5_K_M",
+        file_size_bytes=19_000_000_000,
+    )
+
+    resolved = _resolve_ranked_gguf_for_run(
+        selected,
+        synthetic,
+        [selected, merged_gguf],
+    )
+
+    assert resolved is None
+
+
+def test_resolve_ranked_synthetic_gguf_rejects_conflicting_base_relations():
+    selected = ModelInfo(
+        id="Qwen/Qwen3.6-27B",
+        family_id="qwen3-27b",
+        name="Qwen3.6-27B",
+        parameter_count=27_000_000_000,
+    )
+    merged_gguf = ModelInfo(
+        id="converter/Qwen3.6-27B-GGUF",
+        family_id="qwen3-27b",
+        name="Qwen3.6-27B-GGUF",
+        parameter_count=27_000_000_000,
+        base_model="Qwen/Qwen3.6-27B",
+        base_model_relation="quantized",
+        tags=(
+            "gguf",
+            "base_model:quantized:Qwen/Qwen3.6-27B",
+            "base_model:finetune:Qwen/Qwen3.6-27B",
+        ),
+        gguf_variants=[
+            GGUFVariant(
+                filename="Qwen3.6-27B-Q4_K_M.gguf",
+                quant_type="Q4_K_M",
+                file_size_bytes=16_000_000_000,
+            )
+        ],
+    )
+    synthetic = GGUFVariant(
+        filename="Qwen3.6-27B.Q4_K_M.gguf",
+        quant_type="Q4_K_M",
+        file_size_bytes=16_000_000_000,
+    )
+
+    assert (
+        _resolve_ranked_gguf_for_run(
+            selected,
+            synthetic,
+            [selected, merged_gguf],
+        )
+        is None
+    )
+
+
+def test_resolve_ranked_existing_gguf_repo_does_not_require_base_relation():
+    direct_gguf = ModelInfo(
+        id="author/custom-model-GGUF",
+        family_id="custom-model",
+        name="custom-model-GGUF",
+        parameter_count=7_000_000_000,
+        gguf_variants=[
+            GGUFVariant(
+                filename="custom-model-Q4_K_M.gguf",
+                quant_type="Q4_K_M",
+                file_size_bytes=4_000_000_000,
+            )
+        ],
+    )
+
+    resolved = _resolve_ranked_gguf_for_run(
+        direct_gguf,
+        direct_gguf.gguf_variants[0],
+        [direct_gguf],
+    )
+
+    assert resolved == (direct_gguf, direct_gguf.gguf_variants[0])
+
+
+def test_resolve_ranked_synthetic_gguf_accepts_owner_prefixed_conversion_name():
+    selected = ModelInfo(
+        id="Qwen/Qwen3.6-27B",
+        family_id="qwen3-27b",
+        name="Qwen3.6-27B",
+        parameter_count=27_000_000_000,
+    )
+    direct_gguf = ModelInfo(
+        id="converter/Qwen_Qwen3.6-27B-GGUF",
+        family_id="qwen3-27b",
+        name="Qwen_Qwen3.6-27B-GGUF",
+        parameter_count=27_000_000_000,
+        base_model="Qwen/Qwen3.6-27B",
+        base_model_relation="quantized",
+        tags=("base_model:quantized:Qwen/Qwen3.6-27B",),
+        gguf_variants=[
+            GGUFVariant(
+                filename="Qwen3.6-27B-Q4_K_M.gguf",
+                quant_type="Q4_K_M",
+                file_size_bytes=16_000_000_000,
+            )
+        ],
+    )
+    synthetic = GGUFVariant(
+        filename="Qwen3.6-27B.Q4_K_M.gguf",
+        quant_type="Q4_K_M",
+        file_size_bytes=16_000_000_000,
+    )
+
+    resolved = _resolve_ranked_gguf_for_run(
+        selected,
+        synthetic,
+        [selected, direct_gguf],
+    )
+
+    assert resolved == (direct_gguf, direct_gguf.gguf_variants[0])
 
 
 def test_resolve_ranked_synthetic_gguf_prefers_exact_quant():
@@ -1019,6 +1284,9 @@ def test_resolve_ranked_synthetic_gguf_prefers_exact_quant():
         name="Qwen3.6-27B-GGUF",
         parameter_count=27_000_000_000,
         downloads=10,
+        base_model="Qwen/Qwen3.6-27B",
+        base_model_relation="quantized",
+        tags=("base_model:quantized:Qwen/Qwen3.6-27B",),
         gguf_variants=[
             GGUFVariant(
                 filename="q4.gguf",
@@ -1249,6 +1517,8 @@ def test_run_auto_pick_resolves_ranked_gguf_before_launch(monkeypatch):
         parameter_count=27_000_000_000,
         downloads=200_000,
         base_model="Qwen/Qwen3.6-27B",
+        base_model_relation="quantized",
+        tags=("base_model:quantized:Qwen/Qwen3.6-27B",),
         gguf_variants=[
             GGUFVariant(
                 filename="q4.gguf",

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -348,6 +348,8 @@ def test_models_cache_roundtrip_keeps_published_at():
             published_at="2025-09-17T12:34:56.000Z",
             downloads=123_456,
             likes=789,
+            base_model="Qwen/Qwen3-8B",
+            base_model_relation="quantized",
         )
     ]
     cached = models_to_dicts(models)
@@ -355,6 +357,59 @@ def test_models_cache_roundtrip_keeps_published_at():
     assert len(restored) == 1
     assert restored[0].published_at == "2025-09-17T12:34:56.000Z"
     assert restored[0].downloads == 123_456
+    assert restored[0].base_model_relation == "quantized"
+
+
+def test_parse_model_keeps_quantized_base_model_relation():
+    parsed = _parse_model(
+        {
+            "id": "converter/Qwen3.6-27B-GGUF",
+            "config": {"architectures": ["Qwen2ForCausalLM"]},
+            "gguf": {"total": 27_000_000_000},
+            "siblings": [
+                {
+                    "rfilename": "Qwen3.6-27B-Q4_K_M.gguf",
+                    "size": 16_000_000_000,
+                }
+            ],
+            "cardData": {"base_model": "Qwen/Qwen3.6-27B"},
+            "tags": [
+                "gguf",
+                "base_model:Qwen/Qwen3.6-27B",
+                "base_model:quantized:Qwen/Qwen3.6-27B",
+            ],
+        }
+    )
+
+    assert parsed is not None
+    assert parsed.base_model == "Qwen/Qwen3.6-27B"
+    assert parsed.base_model_relation == "quantized"
+    assert "base_model:quantized:Qwen/Qwen3.6-27B" in parsed.tags
+
+
+def test_parse_model_keeps_finetune_base_model_relation():
+    parsed = _parse_model(
+        {
+            "id": "tuner/Qwen3.6-27B-tuned-GGUF",
+            "config": {"architectures": ["Qwen2ForCausalLM"]},
+            "gguf": {"total": 27_000_000_000},
+            "siblings": [
+                {
+                    "rfilename": "Qwen3.6-27B-tuned-Q4_K_M.gguf",
+                    "size": 16_000_000_000,
+                }
+            ],
+            "cardData": {"base_model": ["Qwen/Qwen3.6-27B"]},
+            "tags": [
+                "gguf",
+                "base_model:Qwen/Qwen3.6-27B",
+                "base_model:finetune:Qwen/Qwen3.6-27B",
+            ],
+        }
+    )
+
+    assert parsed is not None
+    assert parsed.base_model_relation == "finetune"
 
 
 def test_extract_published_at_prefers_created_at():


### PR DESCRIPTION
sorry this took longer than it should have

synthetic GGUF recommendations could resolve to a fine-tune or merged model that only looked related to the recommended checkpoint. this keeps the recommendation and the artifact used by `whichllm run` tied to the same checkpoint.

- Fetch and cache Hugging Face base-model relations and provenance tags
- Require an exclusive `quantized` relation and a matching repository identity
- Reject fine-tunes, merges, conflicting relations, and unproven artifacts
- Invalidate older model caches that don't contain provenance metadata
- Keep direct GGUF selections working as before

One extra case showed up during live validation: `Qwopus3.6-27B-Fusion-GGUF` claimed a quantized relation while also carrying merge provenance. that's covered by the regression tests now too.

validation:
- 479 tests passed on Python 3.11, 3.12, and 3.13
- Ruff check and format check passed
- Live RTX 4090 simulation no longer resolves the Qwen3.6 or Gemma 4 derivative artifacts
- Direct Qwen3-30B-A3B and gpt-oss-20b quantizations still resolve

Fixes #155
