### PR TITLE
release: v0.5.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [0.5.16] - 2026-08-14
+
+### Changed
+
+- Split benchmark caching, fetching, indexing, lineage, lookup, and shared types
+  into focused modules while preserving the existing
+  `whichllm.models.benchmark` import surface. (#41, #143)
+- Locked the uv and Ruff versions used by contributors and required CI checks,
+  so unchanged commits are validated with the same development tools. (#150,
+  #151)
+
+### Fixed
+
+- Generated `whichllm run` and `whichllm snippet` scripts now encode model IDs,
+  GGUF filenames, and quantization types as Python literals, preventing crafted
+  Hugging Face metadata from changing the generated code structure. (#147)
+- Synthetic GGUF recommendations now resolve only to direct quantizations of
+  the selected checkpoint, rejecting fine-tunes, merges, conflicting lineage,
+  and artifacts without explicit provenance. (#155, #156)
+
 ## [0.5.15] - 2026-07-03
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "whichllm"
-version = "0.5.15"
+version = "0.5.16"
 description = "Find the best LLM that runs on your hardware"
 authors = [{name = "Andyyyy64"}]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -572,7 +572,7 @@ wheels = [
 
 [[package]]
 name = "whichllm"
-version = "0.5.15"
+version = "0.5.16"
 source = { editable = "." }
 dependencies = [
     { name = "dbgpu", extra = ["fuzz"] },


### PR DESCRIPTION
sorry this release took a while

v0.5.16 gets the fixes already on main out to PyPI, especially the metadata escaping in generated scripts and the stricter GGUF artifact provenance check.

what's included:
- Escape model IDs, GGUF filenames, and quantization types in generated `run` and `snippet` scripts
- Keep synthetic GGUF recommendations tied to direct quantizations of the selected checkpoint
- Split benchmark fetching, caching, indexing, lineage, and lookup into focused modules
- Lock the development tools used locally and in required CI checks
- Update the changelog and synchronize the project and lockfile versions

validation:
- 479 tests passed on Python 3.11, 3.12, and 3.13
- Ruff check and format check passed
- `uv lock --check` passed with uv 0.11.33
- The wheel and source distribution both report version 0.5.16

publishing the GitHub release and triggering the PyPI workflow will stay a separate step after this PR is merged.
