### PR TITLE
Add -v as CLI synonym for --version

### DIFF
--- a/src/whichllm/cli.py
+++ b/src/whichllm/cli.py
@@ -459,6 +459,7 @@ def main(
     show_version: bool = typer.Option(
         False,
         "--version",
+        "-v",
         help="Show version and exit",
         callback=_print_version,
         is_eager=True,


### PR DESCRIPTION
## What

Add -v as CLI synonym for --version

## Why

Ease of use

## Testing

- [ ] Tests pass (`pytest`)
- [ ] New tests added (if applicable)
- [ ] Tested on real hardware (if hardware-related)

